### PR TITLE
Add Attachment::selection()

### DIFF
--- a/docs/jp/attachments.md
+++ b/docs/jp/attachments.md
@@ -14,6 +14,17 @@ $attachments = [
     [
         'type' => 'directory',
         'path' => '/path/to/dir/',
+        'displayName' => 'dir',// 省略可
+    ],
+    [
+        'type' => 'selection',
+        'filePath' => '/path/to/file.php',
+        'displayName' => 'My File',// ここは省略不可
+        'selection' => [
+            'start' => ['line' => 1, 'character' => 10],
+            'end' => ['line' => 5, 'character' => 10],
+        ],
+        'text' => '...',
     ],
 ];
 
@@ -29,7 +40,10 @@ use Revolution\Copilot\Support\Attachment;
 $attachments = [
     Attachment::file(path: '/path/to/file.php', displayName: 'My File'),
     Attachment::directory(path: '/path/to/dir/', displayName: 'dir'),
+    Attachment::selection(filePath: '/path/to/file.php', displayName: 'My File', selection: ['start' => ['line' => 1, 'character' => 10], 'end' => ['line' => 5, 'character' => 10]], text: '...'),
 ];
 
 $response = Copilot::run(prompt: '...', attachments: $attachments);
 ```
+
+selectionは公式SDKにもまだドキュメントがないので詳細は不明。

--- a/src/Support/Attachment.php
+++ b/src/Support/Attachment.php
@@ -23,4 +23,15 @@ class Attachment
             'displayName' => $displayName,
         ]);
     }
+
+    public static function selection(string $filePath, string $displayName, ?array $selection = null, ?string $text = null): array
+    {
+        return array_filter([
+            'type' => 'selection',
+            'filePath' => $filePath,
+            'displayName' => $displayName,
+            'selection' => $selection,
+            'text' => $text,
+        ]);
+    }
 }

--- a/tests/Unit/Support/AttachmentTest.php
+++ b/tests/Unit/Support/AttachmentTest.php
@@ -19,4 +19,14 @@ describe('Attachment', function () {
             'path' => '/path/to/dir',
         ]);
     });
+
+    it('selection', function () {
+        expect(Attachment::selection(filePath: '/path/to/file.php', displayName: 'My File', selection: ['start' => ['line' => 1, 'character' => 10], 'end' => ['line' => 5, 'character' => 10]], text: '...'))->toBe([
+            'type' => 'selection',
+            'filePath' => '/path/to/file.php',
+            'displayName' => 'My File',
+            'selection' => ['start' => ['line' => 1, 'character' => 10], 'end' => ['line' => 5, 'character' => 10]],
+            'text' => '...',
+        ]);
+    });
 });


### PR DESCRIPTION
Introduce Attachment::selection(...) to create 'selection' attachments (filePath, displayName, optional selection range and text). Update docs/jp/attachments.md with example usage and a note that the selection feature is not yet documented in the official SDK.