### PR TITLE
Default to approveSafety for permission requests

### DIFF
--- a/docs/jp/permission-request.md
+++ b/docs/jp/permission-request.md
@@ -12,7 +12,7 @@
 'permission_approve' => env('COPILOT_PERMISSION_APPROVE', true),
 ```
 
-この設定が有効な場合、`onPermissionRequest`を明示的に指定しなくても`PermissionHandler::approveAll()`が自動的に使われます。
+この設定が有効な場合、`onPermissionRequest`を明示的に指定しなくても`PermissionHandler::approveSafety()`が自動的に使われます。
 
 ```php
 use Revolution\Copilot\Facades\Copilot;
@@ -41,6 +41,22 @@ use Revolution\Copilot\Types\SessionConfig;
 
 $config = new SessionConfig(
     onPermissionRequest: PermissionHandler::approveAll(),
+);
+
+$response = Copilot::run(prompt: 'Hello', config: $config);
+```
+
+## PermissionHandler::approveSafety()
+
+危険性の高い`shell`, `write`のみ拒否して他を自動的に許可する場合は `PermissionHandler::approveSafety()` を使います。
+
+```php
+use Revolution\Copilot\Facades\Copilot;
+use Revolution\Copilot\Support\PermissionHandler;
+use Revolution\Copilot\Types\SessionConfig;
+
+$config = new SessionConfig(
+    onPermissionRequest: PermissionHandler::approveSafety(),
 );
 
 $response = Copilot::run(prompt: 'Hello', config: $config);

--- a/resources/boost/skills/laravel-copilot-sdk-development/SKILL.md
+++ b/resources/boost/skills/laravel-copilot-sdk-development/SKILL.md
@@ -360,7 +360,7 @@ RPC params also accept arrays: `$session->rpc()->mode()->set(['mode' => 'plan'])
 
 ## Permission Requests
 
-By default (`config/copilot.php` → `permission_approve: true`), all permission requests are auto-approved.
+By default (`config/copilot.php` → `permission_approve: true`), all permission requests are auto-approved except for shell and write.
 In web-facing applications or when prompts can be influenced by end users, you should **not** rely on blanket auto-approval. Instead, inspect each request and gate high-risk operations behind your own authorization logic.
 
 Custom handler example:

--- a/src/CopilotManager.php
+++ b/src/CopilotManager.php
@@ -174,7 +174,7 @@ class CopilotManager implements Factory
     {
         if (! isset($config['onPermissionRequest'])) {
             if ($this->config['permission_approve'] ?? config('copilot.permission_approve', true)) {
-                $config['onPermissionRequest'] = PermissionHandler::approveAll();
+                $config['onPermissionRequest'] = PermissionHandler::approveSafety();
             }
         }
 

--- a/src/Support/PermissionHandler.php
+++ b/src/Support/PermissionHandler.php
@@ -20,4 +20,19 @@ final readonly class PermissionHandler
     {
         return fn (array $request, array $invocation): array => PermissionRequestKind::approved();
     }
+
+    /**
+     * A handler that approves all permission requests except for shell and write.
+     *
+     * @return Closure(array, array): array
+     */
+    public static function approveSafety(): Closure
+    {
+        return function (array $request, array $invocation): array {
+            return match ($request['kind'] ?? '') {
+                'shell', 'write' => PermissionRequestKind::deniedInteractivelyByUser(),
+                default => PermissionRequestKind::approved(),
+            };
+        };
+    }
 }

--- a/tests/Unit/Support/PermissionHandlerTest.php
+++ b/tests/Unit/Support/PermissionHandlerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Revolution\Copilot\Support\PermissionHandler;
+use Revolution\Copilot\Support\PermissionRequestKind;
 
 describe('PermissionHandler', function () {
     it('approveAll returns a closure', function () {
@@ -14,6 +15,26 @@ describe('PermissionHandler', function () {
     it('approveAll closure returns approved kind', function () {
         $handler = PermissionHandler::approveAll();
         $result = $handler(['kind' => 'shell'], ['sessionId' => 'test-session']);
+
+        expect($result)->toBe(['kind' => 'approved']);
+    });
+
+    it('approveSafety returns a closure', function () {
+        $handler = PermissionHandler::approveSafety();
+
+        expect($handler)->toBeInstanceOf(Closure::class);
+    });
+
+    it('approveSafety closure returns denied kind', function () {
+        $handler = PermissionHandler::approveSafety();
+        $result = $handler(['kind' => 'shell'], ['sessionId' => 'test-session']);
+
+        expect($result)->toBe(['kind' => PermissionRequestKind::DENIED_INTERACTIVELY_BY_USER]);
+    });
+
+    it('approveSafety closure returns approved kind', function () {
+        $handler = PermissionHandler::approveSafety();
+        $result = $handler(['kind' => 'read'], ['sessionId' => 'test-session']);
 
         expect($result)->toBe(['kind' => 'approved']);
     });


### PR DESCRIPTION
Introduce PermissionHandler::approveSafety() which auto-approves requests except for high-risk kinds ('shell' and 'write') and deny them interactively. Switch CopilotManager's default onPermissionRequest to use approveSafety when permission_approve is enabled. Update Japanese docs and SKILL.md to document the safer default behavior, and add unit tests covering the new handler and expected PermissionRequestKind results.