### PR TITLE
Add PermissionHandler::denyAll() helper

### DIFF
--- a/docs/jp/permission-request.md
+++ b/docs/jp/permission-request.md
@@ -67,14 +67,16 @@ $response = Copilot::run(prompt: 'Hello', config: $config);
 
 これでも完全に安全とは限らないので細かく制御したい場合は`$request['kind']`を見て判定するカスタムハンドラを書いて対応してください。
 
-## すべてを拒否する
+## PermissionHandler::denyAll()
+
+すべてを拒否する場合は`PermissionHandler::denyAll()`を使います。
 
 ```php
-use Revolution\Copilot\Support\PermissionRequestKind;
+use Revolution\Copilot\Support\PermissionHandler;
 use Revolution\Copilot\Types\SessionConfig;
 
 $config = new SessionConfig(
-    onPermissionRequest: fn () => PermissionRequestKind::deniedInteractivelyByUser(),
+    onPermissionRequest: PermissionHandler::denyAll(),
 );
 ```
 

--- a/src/Support/PermissionHandler.php
+++ b/src/Support/PermissionHandler.php
@@ -35,4 +35,14 @@ final readonly class PermissionHandler
             };
         };
     }
+
+    /**
+     * Deny all permission requests.
+     *
+     * @return Closure(array, array): array
+     */
+    public static function denyAll(): Closure
+    {
+        return fn (array $request, array $invocation): array => PermissionRequestKind::deniedInteractivelyByUser();
+    }
 }

--- a/tests/Unit/Support/PermissionHandlerTest.php
+++ b/tests/Unit/Support/PermissionHandlerTest.php
@@ -38,4 +38,11 @@ describe('PermissionHandler', function () {
 
         expect($result)->toBe(['kind' => 'approved']);
     });
+
+    it('denyAll', function () {
+        $handler = PermissionHandler::denyAll();
+        $result = $handler(['kind' => 'read'], ['sessionId' => 'test-session']);
+
+        expect($result)->toBe(['kind' => PermissionRequestKind::DENIED_INTERACTIVELY_BY_USER]);
+    });
 });


### PR DESCRIPTION
This pull request introduces a new helper method to simplify denying all permission requests and updates the documentation and tests to reflect this addition. The main focus is on improving the developer experience when handling permission requests.

**Permission handling improvements:**

* Added a new static method `PermissionHandler::denyAll()` in `PermissionHandler.php` to provide a simple way to deny all permission requests.
* Updated the documentation in `permission-request.md` to recommend using `PermissionHandler::denyAll()` for denying all requests, replacing the previous example.
* Added a unit test in `PermissionHandlerTest.php` to verify the behavior of the new `denyAll` method.