### PR TITLE
Handle protocol v3 broadcast events

### DIFF
--- a/docs/jp/permission-request.md
+++ b/docs/jp/permission-request.md
@@ -187,11 +187,18 @@ kind: "shell" | "write" | "mcp" | "read" | "url" | "custom-tool"
 
 ## レスポンス
 
-許可した場合のJSON-RPCレスポンス例です。idが0だったりresultが二重ですがこうしないと成功しませんでした。
+許可・拒否の結果を配列で返します。`PermissionRequestKind` クラスを使うと便利です。
 
-```json
-{"jsonrpc":"2.0","id":0,"result":{"result":{"kind":"approved"}}}
-``` 
+```php
+return PermissionRequestKind::approved();
+return PermissionRequestKind::deniedInteractivelyByUser();
+```
+
+## プロトコルの詳細
+
+Protocol v3（現在のデフォルト）では、パーミッションリクエストはJSON-RPCリクエストではなくセッションイベント（`permission.requested`）としてブロードキャストされます。SDKはこのイベントを内部的に処理して `session.permissions.handlePendingPermissionRequest` RPCで応答します。
+
+**`SessionConfig` の使い方は変わりません。** `onPermissionRequest` にハンドラを渡すだけで、プロトコルの違いはSDKが吸収します。
 
 ## PermissionRequestKind
 
@@ -211,7 +218,7 @@ if ($confirm) {
 }
 ```
 
-`Laravel\Prompts\confirm`ではなく`Laravel\Prompts\select`を使いたい場合は`PermissionRequestKind::select()`で4つの選択肢を取得できます。
+`Laravel\Prompts\confirm`ではなく`Laravel\Prompts\select`を使いたい場合は`PermissionRequestKind::select()`で選択肢を取得できます。
 
 ```php
 use Revolution\Copilot\Support\PermissionRequestKind;

--- a/docs/jp/rpc.md
+++ b/docs/jp/rpc.md
@@ -119,36 +119,6 @@ $session->rpc()->permissions()->handlePendingPermissionRequest(new SessionPermis
 $session->rpc()->mode()->set(['mode' => 'plan']);
 ```
 
-## プロトコルv3のツール・パーミッション処理
-
-プロトコルv3以降では、ツール呼び出しリクエストとパーミッションリクエストがセッションイベントとして届きます（`external_tool.requested`、`permission.requested`）。
-それらに対してRPCで応答します。
-
-```php
-use Revolution\Copilot\Contracts\CopilotSession;
-use Revolution\Copilot\Facades\Copilot;
-use Revolution\Copilot\Support\PermissionRequestKind;
-use Revolution\Copilot\Types\Rpc\SessionPermissionsHandlePendingPermissionRequestParams;
-use Revolution\Copilot\Types\Rpc\SessionToolsHandlePendingToolCallParams;
-use Revolution\Copilot\Types\SessionEvent;
-use Revolution\Copilot\Enums\SessionEventType;
-
-Copilot::start(function (CopilotSession $session) {
-    $session->on(function (SessionEvent $event) use ($session): void {
-        if ($event->is(SessionEventType::EXTERNAL_TOOL_REQUESTED)) {
-            $session->rpc()->tools()->handlePendingToolCall(
-                new SessionToolsHandlePendingToolCallParams(
-                    requestId: $event->data('requestId'),
-                    result: 'ツールの実行結果',
-                )
-            );
-        }
-    });
-
-    $session->sendAndWait(prompt: '...');
-});
-```
-
 ## Testing
 
 `Copilot::fake()`でのモックは使えないので`Copilot::expects('client')`や`Copilot::expects('start')`でモックしてください。

--- a/docs/jp/tools.md
+++ b/docs/jp/tools.md
@@ -82,3 +82,22 @@ Artisan::command('copilot:tools', function () {
     }, config: $config);
 });
 ```
+
+## $invocation
+
+ツールハンドラの第2引数 `$invocation` には以下のフィールドが渡されます。
+
+```php
+[
+    'sessionId'  => '...',
+    'toolCallId' => '...',
+    'toolName'   => 'lookup_fact',
+    'arguments'  => [...], // ツール引数（$params と同じ内容）
+]
+```
+
+## プロトコルの詳細
+
+Protocol v3（現在のデフォルト）では、ツール呼び出しはJSON-RPCリクエストではなくセッションイベント（`external_tool.requested`）としてブロードキャストされます。SDKはこのイベントを内部的に処理して `session.tools.handlePendingToolCall` RPCで応答します。
+
+**`SessionConfig` の使い方は変わりません。** `tools` に定義を渡すだけで、プロトコルの違いはSDKが吸収します。

--- a/src/Session.php
+++ b/src/Session.php
@@ -21,8 +21,11 @@ use Revolution\Copilot\JsonRpc\JsonRpcClient;
 use Revolution\Copilot\Rpc\SessionRpc;
 use Revolution\Copilot\Support\PermissionRequestKind;
 use Revolution\Copilot\Types\Rpc\SessionModelSwitchToParams;
+use Revolution\Copilot\Types\Rpc\SessionPermissionsHandlePendingPermissionRequestParams;
+use Revolution\Copilot\Types\Rpc\SessionToolsHandlePendingToolCallParams;
 use Revolution\Copilot\Types\SessionEvent;
 use Revolution\Copilot\Types\SessionHooks;
+use Revolution\Copilot\Types\ToolResultObject;
 use Revolution\Copilot\Types\UserInputRequest;
 use Revolution\Copilot\Types\UserInputResponse;
 use Throwable;
@@ -458,12 +461,17 @@ class Session implements CopilotSession
 
     /**
      * Dispatch an event to all registered handlers.
+     * Also handles broadcast request events internally (external tool calls, permissions).
      *
      * @internal
      */
     public function dispatchEvent(SessionEvent $event): void
     {
         SessionEventReceived::dispatch($this->sessionId, $event);
+
+        // Handle broadcast request events internally (protocol v3+) before dispatching to user handlers.
+        // Fire-and-forget: responses are sent asynchronously via RPC using a new Fiber.
+        $this->handleBroadcastEvent($event);
 
         // Dispatch to typed handlers for this specific event type
         $eventType = $event->type();
@@ -488,8 +496,139 @@ class Session implements CopilotSession
     }
 
     /**
-     * Register tool handlers.
+     * Handle broadcast request events (protocol v3+) by executing local handlers
+     * and responding via RPC. Uses a new Fiber to allow async RPC calls (fire-and-forget).
      *
+     * @internal
+     */
+    protected function handleBroadcastEvent(SessionEvent $event): void
+    {
+        if ($event->is(SessionEventType::EXTERNAL_TOOL_REQUESTED)) {
+            $requestId = $event->data['requestId'] ?? null;
+            $toolName = $event->data['toolName'] ?? null;
+            $arguments = $event->data['arguments'] ?? [];
+            $toolCallId = $event->data['toolCallId'] ?? null;
+
+            if ($requestId === null || $toolName === null) {
+                return;
+            }
+
+            $handler = $this->getToolHandler($toolName);
+
+            if ($handler === null) {
+                return; // This client doesn't handle this tool; another client will.
+            }
+
+            $this->executeToolAndRespond($requestId, $toolName, $toolCallId, $arguments, $handler);
+        } elseif ($event->is(SessionEventType::PERMISSION_REQUESTED)) {
+            $requestId = $event->data['requestId'] ?? null;
+            $permissionRequest = $event->data['permissionRequest'] ?? [];
+
+            if ($requestId === null || $this->permissionHandler === null) {
+                return;
+            }
+
+            $this->executePermissionAndRespond($requestId, $permissionRequest);
+        }
+    }
+
+    /**
+     * Execute a tool handler and send the result back via RPC.
+     * Runs in a new Fiber to allow async RPC calls without blocking the event loop.
+     *
+     * @internal
+     */
+    protected function executeToolAndRespond(string $requestId, string $toolName, ?string $toolCallId, mixed $arguments, Closure $handler): void
+    {
+        $fiber = new \Fiber(function () use ($requestId, $toolName, $toolCallId, $arguments, $handler): void {
+            try {
+                $invocation = [
+                    'sessionId' => $this->sessionId,
+                    'toolCallId' => $toolCallId,
+                    'toolName' => $toolName,
+                    'arguments' => $arguments,
+                ];
+
+                /** @var ToolResultObject|array|string|mixed $rawResult */
+                $rawResult = $handler($arguments, $invocation);
+
+                if ($rawResult instanceof ToolResultObject) {
+                    $result = $rawResult->toArray();
+                } elseif (is_string($rawResult) || is_array($rawResult)) {
+                    $result = $rawResult;
+                } else {
+                    $result = $rawResult !== null ? (string) $rawResult : '';
+                }
+
+                // Send failure via error param for consistent server-side formatting
+                if (is_array($result) && ($result['resultType'] ?? null) === 'failure' && isset($result['error'])) {
+                    $this->rpc()->tools()->handlePendingToolCall(
+                        new SessionToolsHandlePendingToolCallParams(
+                            requestId: $requestId,
+                            error: $result['error'],
+                        )
+                    );
+                } else {
+                    $this->rpc()->tools()->handlePendingToolCall(
+                        new SessionToolsHandlePendingToolCallParams(
+                            requestId: $requestId,
+                            result: $result,
+                        )
+                    );
+                }
+            } catch (Throwable $e) {
+                try {
+                    $this->rpc()->tools()->handlePendingToolCall(
+                        new SessionToolsHandlePendingToolCallParams(
+                            requestId: $requestId,
+                            error: $e->getMessage(),
+                        )
+                    );
+                } catch (Throwable) {
+                    // Connection lost or RPC error — nothing we can do
+                }
+            }
+        });
+
+        $fiber->start();
+    }
+
+    /**
+     * Execute the permission handler and send the result back via RPC.
+     * Runs in a new Fiber to allow async RPC calls without blocking the event loop.
+     *
+     * @internal
+     */
+    protected function executePermissionAndRespond(string $requestId, array $permissionRequest): void
+    {
+        $fiber = new \Fiber(function () use ($requestId, $permissionRequest): void {
+            try {
+                $result = ($this->permissionHandler)($permissionRequest, ['sessionId' => $this->sessionId]);
+
+                $this->rpc()->permissions()->handlePendingPermissionRequest(
+                    new SessionPermissionsHandlePendingPermissionRequestParams(
+                        requestId: $requestId,
+                        result: $result,
+                    )
+                );
+            } catch (Throwable) {
+                try {
+                    $this->rpc()->permissions()->handlePendingPermissionRequest(
+                        new SessionPermissionsHandlePendingPermissionRequestParams(
+                            requestId: $requestId,
+                            result: PermissionRequestKind::deniedNoApprovalRuleAndCouldNotRequestFromUser(),
+                        )
+                    );
+                } catch (Throwable) {
+                    // Connection lost or RPC error — nothing we can do
+                }
+            }
+        });
+
+        $fiber->start();
+    }
+
+    /**
      * @param  array<array{name: string, handler: Closure}>  $tools
      *
      * @internal


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of protocol v3 session events for tool calls and permission requests, ensuring that these events are processed internally and responded to asynchronously via RPC. The main changes include the addition of internal event handling logic in the `Session` class, updates to the documentation to clarify protocol v3 behavior, and improved error handling for tool and permission results.

**Session event handling improvements:**

* Added the `handleBroadcastEvent`, `executeToolAndRespond`, and `executePermissionAndRespond` methods to the `Session` class. These methods allow the SDK to intercept protocol v3 broadcast events (`external_tool.requested` and `permission.requested`), execute the appropriate local handlers, and send responses asynchronously using Fibers and the relevant RPC methods. This ensures non-blocking, fire-and-forget behavior for tool and permission handling. [[1]](diffhunk://#diff-2ba5884bab6c9e8a5ee8ea4740bbb6d0c44f4340e4b86d532c7a0f36f17d2c25R464-R475) [[2]](diffhunk://#diff-2ba5884bab6c9e8a5ee8ea4740bbb6d0c44f4340e4b86d532c7a0f36f17d2c25L491-R631)

* Improved error handling for tool and permission responses: If a tool handler throws an exception or returns a failure result, the error is sent back via the appropriate RPC call, ensuring consistent server-side formatting and robust error reporting.

**Documentation updates for protocol v3:**

* Updated `docs/jp/permission-request.md` and `docs/jp/tools.md` to clarify that, under protocol v3, tool and permission requests are broadcast as session events rather than standard JSON-RPC requests. The documentation now explains that the SDK absorbs protocol differences, and developers only need to provide handlers as before. [[1]](diffhunk://#diff-9d9062b1df5d1e56ef878db350ca56e8d818d814f08bc8bcd02b6372645fb8a1L190-R202) [[2]](diffhunk://#diff-34e99794a12709174fb23d14a7376649520cc1282f1ee6d085aef7634bad013cR85-R103)

* Removed outdated protocol v3 handling examples from `docs/jp/rpc.md` to avoid confusion, since the SDK now manages these events internally.

* Added explanation of the `$invocation` parameter for tool handlers in the documentation, detailing the structure and available fields.

These changes simplify the developer experience for protocol v3, improve reliability, and ensure consistent handling of tool and permission events.