### PR TITLE
Renamed to `PermissionRequestResultKind` match the official SDK

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,7 +163,7 @@ src/
 │   └── Pending*.php            # Python版の*Apiと同様の中間クラス
 ├── Support/                     # 分類しにくいヘルパークラス
 │   ├── Attachment.php
-│   └── PermissionRequestKind.php
+│   └── PermissionRequestResultKind.php
 ├── Testing/
 │   ├── CopilotFake.php         # テスト用モック
 │   ├── FakeSession.php

--- a/docs/jp/permission-request.md
+++ b/docs/jp/permission-request.md
@@ -187,11 +187,11 @@ kind: "shell" | "write" | "mcp" | "read" | "url" | "custom-tool"
 
 ## レスポンス
 
-許可・拒否の結果を配列で返します。`PermissionRequestKind` クラスを使うと便利です。
+許可・拒否の結果を配列で返します。`PermissionRequestResultKind` クラスを使うと便利です。
 
 ```php
-return PermissionRequestKind::approved();
-return PermissionRequestKind::deniedInteractivelyByUser();
+return PermissionRequestResultKind::approved();
+return PermissionRequestResultKind::deniedInteractivelyByUser();
 ```
 
 ## プロトコルの詳細
@@ -200,33 +200,33 @@ Protocol v3（現在のデフォルト）では、パーミッションリクエ
 
 **`SessionConfig` の使い方は変わりません。** `onPermissionRequest` にハンドラを渡すだけで、プロトコルの違いはSDKが吸収します。
 
-## PermissionRequestKind
+## PermissionRequestResultKind
 
-`['kind' => 'approved']`の形式で返せばよいですが分かりにくいのでPermissionRequestKindクラスも用意しています。
+`['kind' => 'approved']`の形式で返せばよいですが分かりにくいので`PermissionRequestResultKind`クラスも用意しています。
 
 ```php
-use Revolution\Copilot\Support\PermissionRequestKind;
+use Revolution\Copilot\Support\PermissionRequestResultKind;
 
 $confirm = confirm(
     label: 'Do you accept the requested permissions?',
 );
 
 if ($confirm) {
-    return PermissionRequestKind::approved();
+    return PermissionRequestResultKind::approved();
 } else {
-    return PermissionRequestKind::deniedInteractivelyByUser();
+    return PermissionRequestResultKind::deniedInteractivelyByUser();
 }
 ```
 
-`Laravel\Prompts\confirm`ではなく`Laravel\Prompts\select`を使いたい場合は`PermissionRequestKind::select()`で選択肢を取得できます。
+`Laravel\Prompts\confirm`ではなく`Laravel\Prompts\select`を使いたい場合は`PermissionRequestResultKind::select()`で選択肢を取得できます。
 
 ```php
-use Revolution\Copilot\Support\PermissionRequestKind;
+use Revolution\Copilot\Support\PermissionRequestResultKind;
 use function Laravel\Prompts\select;
 
 $select = select(
     label: 'Do you accept the requested permissions?',
-    options: PermissionRequestKind::select(),
+    options: PermissionRequestResultKind::select(),
 );
 
 return ['kind' => $select];

--- a/docs/jp/rpc.md
+++ b/docs/jp/rpc.md
@@ -107,7 +107,7 @@ $session->rpc()->tools()->handlePendingToolCall(new SessionToolsHandlePendingToo
 // permissions (プロトコルv3+: permission.requestedイベントへの応答)
 $session->rpc()->permissions()->handlePendingPermissionRequest(new SessionPermissionsHandlePendingPermissionRequestParams(
     requestId: '...',
-    result: PermissionRequestKind::approved(),
+    result: PermissionRequestResultKind::approved(),
 ));
 ```
 

--- a/resources/boost/skills/laravel-copilot-sdk-development/SKILL.md
+++ b/resources/boost/skills/laravel-copilot-sdk-development/SKILL.md
@@ -364,8 +364,9 @@ By default (`config/copilot.php` → `permission_approve: true`), all permission
 In web-facing applications or when prompts can be influenced by end users, you should **not** rely on blanket auto-approval. Instead, inspect each request and gate high-risk operations behind your own authorization logic.
 
 Custom handler example:
+
 ```php
-use Revolution\Copilot\Support\PermissionRequestKind;
+use Revolution\Copilot\Support\PermissionRequestResultKind;
 
 $config = new SessionConfig(
     onPermissionRequest: function (array $request, array $invocation) {
@@ -374,7 +375,7 @@ $config = new SessionConfig(
             case 'shell':
             case 'write':
                 // High-risk operations: require explicit application-level authorization or deny by default.
-                return PermissionRequestKind::deniedInteractivelyByUser();
+                return PermissionRequestResultKind::deniedInteractivelyByUser();
 
             case 'read':
             case 'url':
@@ -382,7 +383,7 @@ $config = new SessionConfig(
             case 'custom-tool':
             default:
                 // Lower-risk operations: adjust this to your own policies (per-user confirmation, permissions, etc.).
-                return PermissionRequestKind::approved();
+                return PermissionRequestResultKind::approved();
         }
     },
 );

--- a/resources/boost/skills/laravel-copilot-sdk-development/SKILL.md
+++ b/resources/boost/skills/laravel-copilot-sdk-development/SKILL.md
@@ -531,4 +531,4 @@ The SDK dispatches Laravel events for logging and debugging:
 | `Attachment` | `Attachment::file()`, `Attachment::directory()`, `Attachment::selection()` |
 | `ServerRpc` / `SessionRpc` | Typed RPC layer |
 | `PermissionHandler` | `PermissionHandler::approveAll()` |
-| `PermissionRequestKind` | `approved()`, `deniedInteractivelyByUser()`, `select()` |
+| `PermissionRequestResultKind` | `approved()`, `deniedInteractivelyByUser()`, `select()` |

--- a/src/Rpc/SessionRpc.php
+++ b/src/Rpc/SessionRpc.php
@@ -21,7 +21,7 @@ use Revolution\Copilot\JsonRpc\JsonRpcClient;
  * $session->rpc()->agent()->list();
  * $session->rpc()->compaction()->compact();
  * $session->rpc()->tools()->handlePendingToolCall(new SessionToolsHandlePendingToolCallParams(requestId: '...', result: 'done'));
- * $session->rpc()->permissions()->handlePendingPermissionRequest(new SessionPermissionsHandlePendingPermissionRequestParams(requestId: '...', result: PermissionRequestKind::approved()));
+ * $session->rpc()->permissions()->handlePendingPermissionRequest(new SessionPermissionsHandlePendingPermissionRequestParams(requestId: '...', result: PermissionRequestResultKind::approved()));
  * ```
  */
 class SessionRpc

--- a/src/Session.php
+++ b/src/Session.php
@@ -19,7 +19,7 @@ use Revolution\Copilot\Exceptions\SessionErrorException;
 use Revolution\Copilot\Exceptions\SessionTimeoutException;
 use Revolution\Copilot\JsonRpc\JsonRpcClient;
 use Revolution\Copilot\Rpc\SessionRpc;
-use Revolution\Copilot\Support\PermissionRequestKind;
+use Revolution\Copilot\Support\PermissionRequestResultKind;
 use Revolution\Copilot\Types\Rpc\SessionModelSwitchToParams;
 use Revolution\Copilot\Types\Rpc\SessionPermissionsHandlePendingPermissionRequestParams;
 use Revolution\Copilot\Types\Rpc\SessionToolsHandlePendingToolCallParams;
@@ -616,7 +616,7 @@ class Session implements CopilotSession
                     $this->rpc()->permissions()->handlePendingPermissionRequest(
                         new SessionPermissionsHandlePendingPermissionRequestParams(
                             requestId: $requestId,
-                            result: PermissionRequestKind::deniedNoApprovalRuleAndCouldNotRequestFromUser(),
+                            result: PermissionRequestResultKind::deniedNoApprovalRuleAndCouldNotRequestFromUser(),
                         )
                     );
                 } catch (Throwable) {
@@ -674,13 +674,13 @@ class Session implements CopilotSession
     public function handlePermissionRequest(array $request): array
     {
         if ($this->permissionHandler === null) {
-            return PermissionRequestKind::deniedNoApprovalRuleAndCouldNotRequestFromUser();
+            return PermissionRequestResultKind::deniedNoApprovalRuleAndCouldNotRequestFromUser();
         }
 
         try {
             return ($this->permissionHandler)($request, ['sessionId' => $this->sessionId]);
         } catch (Throwable) {
-            return PermissionRequestKind::deniedNoApprovalRuleAndCouldNotRequestFromUser();
+            return PermissionRequestResultKind::deniedNoApprovalRuleAndCouldNotRequestFromUser();
         }
     }
 

--- a/src/Support/PermissionHandler.php
+++ b/src/Support/PermissionHandler.php
@@ -18,7 +18,7 @@ final readonly class PermissionHandler
      */
     public static function approveAll(): Closure
     {
-        return fn (array $request, array $invocation): array => PermissionRequestKind::approved();
+        return fn (array $request, array $invocation): array => PermissionRequestResultKind::approved();
     }
 
     /**
@@ -30,8 +30,8 @@ final readonly class PermissionHandler
     {
         return function (array $request, array $invocation): array {
             return match ($request['kind'] ?? '') {
-                'shell', 'write' => PermissionRequestKind::deniedInteractivelyByUser(),
-                default => PermissionRequestKind::approved(),
+                'shell', 'write' => PermissionRequestResultKind::deniedInteractivelyByUser(),
+                default => PermissionRequestResultKind::approved(),
             };
         };
     }
@@ -43,6 +43,6 @@ final readonly class PermissionHandler
      */
     public static function denyAll(): Closure
     {
-        return fn (array $request, array $invocation): array => PermissionRequestKind::deniedInteractivelyByUser();
+        return fn (array $request, array $invocation): array => PermissionRequestResultKind::deniedInteractivelyByUser();
     }
 }

--- a/src/Support/PermissionRequestResultKind.php
+++ b/src/Support/PermissionRequestResultKind.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Revolution\Copilot\Support;
 
-/**
- * The other language versions are only defined as strings.
- * Make it easy to use with static methods.
- */
-final readonly class PermissionRequestKind
+final readonly class PermissionRequestResultKind
 {
     public const string APPROVED = 'approved';
 

--- a/src/Types/Rpc/SessionPermissionsHandlePendingPermissionRequestParams.php
+++ b/src/Types/Rpc/SessionPermissionsHandlePendingPermissionRequestParams.php
@@ -16,7 +16,7 @@ use Illuminate\Contracts\Support\Arrayable;
  * - "denied-interactively-by-user" (with optional "feedback" string)
  * - "denied-by-content-exclusion-policy" (with required "path" and "message" strings)
  *
- * Use {@see \Revolution\Copilot\Support\PermissionRequestKind} for building result arrays.
+ * Use {@see \Revolution\Copilot\Support\PermissionRequestResultKind} for building result arrays.
  */
 readonly class SessionPermissionsHandlePendingPermissionRequestParams implements Arrayable
 {

--- a/tests/Unit/Support/PermissionHandlerTest.php
+++ b/tests/Unit/Support/PermissionHandlerTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Revolution\Copilot\Support\PermissionHandler;
-use Revolution\Copilot\Support\PermissionRequestKind;
+use Revolution\Copilot\Support\PermissionRequestResultKind;
 
 describe('PermissionHandler', function () {
     it('approveAll returns a closure', function () {
@@ -29,7 +29,7 @@ describe('PermissionHandler', function () {
         $handler = PermissionHandler::approveSafety();
         $result = $handler(['kind' => 'shell'], ['sessionId' => 'test-session']);
 
-        expect($result)->toBe(['kind' => PermissionRequestKind::DENIED_INTERACTIVELY_BY_USER]);
+        expect($result)->toBe(['kind' => PermissionRequestResultKind::DENIED_INTERACTIVELY_BY_USER]);
     });
 
     it('approveSafety closure returns approved kind', function () {
@@ -43,6 +43,6 @@ describe('PermissionHandler', function () {
         $handler = PermissionHandler::denyAll();
         $result = $handler(['kind' => 'read'], ['sessionId' => 'test-session']);
 
-        expect($result)->toBe(['kind' => PermissionRequestKind::DENIED_INTERACTIVELY_BY_USER]);
+        expect($result)->toBe(['kind' => PermissionRequestResultKind::DENIED_INTERACTIVELY_BY_USER]);
     });
 });

--- a/tests/Unit/Support/PermissionRequestKindTest.php
+++ b/tests/Unit/Support/PermissionRequestKindTest.php
@@ -2,43 +2,43 @@
 
 declare(strict_types=1);
 
-use Revolution\Copilot\Support\PermissionRequestKind;
+use Revolution\Copilot\Support\PermissionRequestResultKind;
 
 describe('PermissionRequestKind', function () {
     it('approved', function () {
-        expect(PermissionRequestKind::approved())->toContain('approved');
+        expect(PermissionRequestResultKind::approved())->toContain('approved');
     });
 
     it('deniedByRules', function () {
-        expect(PermissionRequestKind::deniedByRules())->toContain('denied-by-rules');
+        expect(PermissionRequestResultKind::deniedByRules())->toContain('denied-by-rules');
     });
 
     it('deniedNoApprovalRuleAndCouldNotRequestFromUser', function () {
-        expect(PermissionRequestKind::deniedNoApprovalRuleAndCouldNotRequestFromUser()['kind'])->toBe('denied-no-approval-rule-and-could-not-request-from-user');
+        expect(PermissionRequestResultKind::deniedNoApprovalRuleAndCouldNotRequestFromUser()['kind'])->toBe('denied-no-approval-rule-and-could-not-request-from-user');
     });
 
     it('deniedInteractivelyByUser', function () {
-        expect(PermissionRequestKind::deniedInteractivelyByUser()['kind'])->toBe('denied-interactively-by-user');
+        expect(PermissionRequestResultKind::deniedInteractivelyByUser()['kind'])->toBe('denied-interactively-by-user');
     });
 
     it('deniedInteractivelyByUser with feedback', function () {
-        $result = PermissionRequestKind::deniedInteractivelyByUser('Too risky');
+        $result = PermissionRequestResultKind::deniedInteractivelyByUser('Too risky');
         expect($result['kind'])->toBe('denied-interactively-by-user')
             ->and($result['feedback'])->toBe('Too risky');
     });
 
     it('deniedByContentExclusionPolicy', function () {
-        $result = PermissionRequestKind::deniedByContentExclusionPolicy('/secret/file.txt', 'Excluded by policy');
+        $result = PermissionRequestResultKind::deniedByContentExclusionPolicy('/secret/file.txt', 'Excluded by policy');
         expect($result['kind'])->toBe('denied-by-content-exclusion-policy')
             ->and($result['path'])->toBe('/secret/file.txt')
             ->and($result['message'])->toBe('Excluded by policy');
     });
 
     it('select includes content exclusion policy', function () {
-        expect(PermissionRequestKind::select())->toHaveKey('denied-by-content-exclusion-policy');
+        expect(PermissionRequestResultKind::select())->toHaveKey('denied-by-content-exclusion-policy');
     });
 
     it('select', function () {
-        expect(PermissionRequestKind::select())->toHaveKeys(['approved', 'denied-interactively-by-user']);
+        expect(PermissionRequestResultKind::select())->toHaveKeys(['approved', 'denied-interactively-by-user']);
     });
 });

--- a/tests/Unit/Support/PermissionRequestResultKindTest.php
+++ b/tests/Unit/Support/PermissionRequestResultKindTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Revolution\Copilot\Support\PermissionRequestResultKind;
 
-describe('PermissionRequestKind', function () {
+describe('PermissionRequestResultKind', function () {
     it('approved', function () {
         expect(PermissionRequestResultKind::approved())->toContain('approved');
     });

--- a/workbench/routes/console.php
+++ b/workbench/routes/console.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Concurrency;
 use Revolution\Copilot\Contracts\CopilotSession;
 use Revolution\Copilot\Facades\Copilot;
-use Revolution\Copilot\Support\PermissionRequestKind;
+use Revolution\Copilot\Support\PermissionRequestResultKind;
 use Revolution\Copilot\Types\Hooks\PreToolUseHookOutput;
 use Revolution\Copilot\Types\ModelInfo;
 use Revolution\Copilot\Types\ResumeSessionConfig;
@@ -60,9 +60,9 @@ Artisan::command('copilot:chat {--resume}', function () {
             );
 
             if ($confirm) {
-                return PermissionRequestKind::approved();
+                return PermissionRequestResultKind::approved();
             } else {
-                return PermissionRequestKind::deniedInteractivelyByUser();
+                return PermissionRequestResultKind::deniedInteractivelyByUser();
             }
         },
         mcpServers: $mcp,


### PR DESCRIPTION
This pull request refactors the permission request result handling throughout the codebase by renaming the class `PermissionRequestKind` to `PermissionRequestResultKind`. All references, usages, documentation, and tests have been updated to use the new name. This change improves clarity and consistency in how permission request results are represented and used.

Refactor: Permission Request Result Kind

* Renamed the class `PermissionRequestKind` to `PermissionRequestResultKind` and updated all usages across the codebase, including in `src/Support/PermissionHandler.php`, `src/Session.php`, `src/Rpc/SessionRpc.php`, and related files. (`src/Support/PermissionRequestResultKind.php`, `src/Support/PermissionHandler.php`, `src/Session.php`, `src/Rpc/SessionRpc.php`, [[1]](diffhunk://#diff-ec88e2b5d523556f42bf9cace85567d247aa510c3582ddce750ebd822646b074L7-R7) [[2]](diffhunk://#diff-a65dcb92e25f41bb21872c3710311503dac9a28da272f375a609014e8162484dL21-R21) [[3]](diffhunk://#diff-a65dcb92e25f41bb21872c3710311503dac9a28da272f375a609014e8162484dL33-R34) [[4]](diffhunk://#diff-a65dcb92e25f41bb21872c3710311503dac9a28da272f375a609014e8162484dL46-R46) [[5]](diffhunk://#diff-2ba5884bab6c9e8a5ee8ea4740bbb6d0c44f4340e4b86d532c7a0f36f17d2c25L22-R22) [[6]](diffhunk://#diff-2ba5884bab6c9e8a5ee8ea4740bbb6d0c44f4340e4b86d532c7a0f36f17d2c25L619-R619) [[7]](diffhunk://#diff-2ba5884bab6c9e8a5ee8ea4740bbb6d0c44f4340e4b86d532c7a0f36f17d2c25L677-R683) [[8]](diffhunk://#diff-b46121a45114c094e3ebbbb92c5f656274f0e7254ab228c1db9114d592d0dd40L24-R24) [[9]](diffhunk://#diff-06e9fab39581411b22d8d6a21baa3065dce3de6e364684b3af5f1518d0c87106L10-R10) [[10]](diffhunk://#diff-06e9fab39581411b22d8d6a21baa3065dce3de6e364684b3af5f1518d0c87106L63-R65)

Documentation updates

* Updated all documentation references from `PermissionRequestKind` to `PermissionRequestResultKind` in markdown files and code examples to match the new class name. (`docs/jp/permission-request.md`, `.github/copilot-instructions.md`, `resources/boost/skills/laravel-copilot-sdk-development/SKILL.md`, [[1]](diffhunk://#diff-9d9062b1df5d1e56ef878db350ca56e8d818d814f08bc8bcd02b6372645fb8a1L190-R194) [[2]](diffhunk://#diff-9d9062b1df5d1e56ef878db350ca56e8d818d814f08bc8bcd02b6372645fb8a1L203-R229) [[3]](diffhunk://#diff-37fbf880253a5e01dbb59b27a22932daa7fe5aa874984d8f27039e136494a20dR367-R369) [[4]](diffhunk://#diff-37fbf880253a5e01dbb59b27a22932daa7fe5aa874984d8f27039e136494a20dL377-R386) [[5]](diffhunk://#diff-37fbf880253a5e01dbb59b27a22932daa7fe5aa874984d8f27039e136494a20dL533-R534) [[6]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L166-R166)

Test updates

* Removed the old test file `tests/Unit/Support/PermissionRequestKindTest.php` and added a new test file `tests/Unit/Support/PermissionRequestResultKindTest.php` to reflect the class rename and ensure test coverage. [[1]](diffhunk://#diff-209cd011e4234d0b95c147a5dabf37277f83c888744f65a6a66189a094f3be03L1-L44) [[2]](diffhunk://#diff-6ae75575e996ee2e5a410d528e90cca604679e25afc0fd4571856bce9389b31cR1-R44)
* Updated all relevant tests to use `PermissionRequestResultKind` instead of `PermissionRequestKind`. (`tests/Unit/Support/PermissionHandlerTest.php`, [[1]](diffhunk://#diff-41ca719b5035cdae3640b73550820e54d7db8a56ce7549473b0b081d511a3919L6-R6) [[2]](diffhunk://#diff-41ca719b5035cdae3640b73550820e54d7db8a56ce7549473b0b081d511a3919L32-R32) [[3]](diffhunk://#diff-41ca719b5035cdae3640b73550820e54d7db8a56ce7549473b0b081d511a3919L46-R46)

SDK and type references

* Updated references in SDK types and comments to use the new class name, ensuring consistency in developer-facing documentation and code. (`src/Types/Rpc/SessionPermissionsHandlePendingPermissionRequestParams.php`, [src/Types/Rpc/SessionPermissionsHandlePendingPermissionRequestParams.phpL19-R19](diffhunk://#diff-2c93a14b92ef7c6677a6b3ecbe2eba6db8b00698e0ddc3f46d0030008f292c13L19-R19))