### PR TITLE
Add W3C Trace Context propagation for OpenTelemetry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,9 @@
             "@php vendor/bin/testbench serve --ansi"
         ]
     },
+    "suggest": {
+        "open-telemetry/api": "Required for automatic W3C Trace Context propagation between your app and the Copilot CLI"
+    },
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true

--- a/config/copilot.php
+++ b/config/copilot.php
@@ -110,4 +110,27 @@ return [
     |
     */
     'permission_approve' => env('COPILOT_PERMISSION_APPROVE', 'deny-all'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | OpenTelemetry / Telemetry
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for OpenTelemetry instrumentation of the Copilot CLI process.
+    | When provided, these settings are translated into environment variables
+    | on the spawned CLI server process.
+    |
+    | Set `telemetry` to an array with any of the following keys:
+    |   - otlpEndpoint:   OTLP HTTP endpoint URL (e.g., "http://localhost:4318")
+    |   - filePath:       File path for JSON-lines trace output
+    |   - exporterType:   "otlp-http" or "file"
+    |   - sourceName:     Instrumentation scope name
+    |   - captureContent: Whether to capture message content (prompts, responses)
+    |
+    | Set to null to disable telemetry.
+    |
+    | Note: This option is ignored when 'url' is set (TCP mode).
+    |
+    */
+    'telemetry' => null,
 ];

--- a/docs/jp/telemetry.md
+++ b/docs/jp/telemetry.md
@@ -1,0 +1,128 @@
+# OpenTelemetry
+
+Copilot CLIにはOpenTelemetryによるトレース機能が組み込まれています。SDK側で設定するだけで、CLIプロセスのトレースデータを収集できます。
+
+## 基本的な使い方
+
+### CLIプロセスのトレース有効化
+
+`config/copilot.php`にtelemetry設定を追加するか、直接オプションで指定します。
+
+```php
+// config/copilot.php
+'telemetry' => [
+    'otlpEndpoint' => 'http://localhost:4318',
+],
+```
+
+または直接指定:
+
+```php
+use Revolution\Copilot\Facades\Copilot;
+use Revolution\Copilot\Types\TelemetryConfig;
+
+Copilot::useStdio([
+    'telemetry' => new TelemetryConfig(
+        otlpEndpoint: 'http://localhost:4318',
+    )
+]);
+
+$response = Copilot::run(prompt: 'Hello');
+```
+
+クライアントを直接使う場合:
+
+```php
+use Revolution\Copilot\Client;
+use Revolution\Copilot\Types\TelemetryConfig;
+
+$client = new Client([
+    'telemetry' => new TelemetryConfig(
+        otlpEndpoint: 'http://localhost:4318',
+    ),
+]);
+```
+
+### TelemetryConfigオプション
+
+| オプション | 説明 |
+|---|---|
+| `otlpEndpoint` | OTLP HTTPエンドポイントURL |
+| `filePath` | JSON-linesトレース出力のファイルパス |
+| `exporterType` | `"otlp-http"` または `"file"` |
+| `sourceName` | インストルメンテーションスコープ名 |
+| `captureContent` | メッセージ内容（プロンプト、レスポンス）をキャプチャするか |
+
+## W3C Trace Context プロパゲーション
+
+> **ほとんどのユーザーにはこの機能は不要です。** 上記のTelemetryConfigだけでCLIのトレースを収集できます。以下は**アプリケーション側で独自のOpenTelemetryスパンを作成し、CLIのスパンと同じ分散トレースに表示させたい場合**の高度な機能です。
+
+SDKは`session.create`、`session.resume`、`session.send`のJSON-RPCリクエストにW3C Trace Context（`traceparent`/`tracestate`）を自動的に注入します。
+
+### 自動プロパゲーション（推奨）
+
+`open-telemetry/api`パッケージをインストールするだけで、トレースコンテキストが自動的に伝搬されます。
+
+```shell
+composer require open-telemetry/api open-telemetry/sdk
+```
+
+インストール後は特別な設定不要で、アプリケーションのスパンとCLIのスパンが同一の分散トレースにリンクされます。
+
+### カスタムプロバイダー
+
+独自のトレースコンテキスト取得ロジックを使いたい場合:
+
+```php
+use Revolution\Copilot\Support\TraceContext;
+
+TraceContext::useProvider(function (): array {
+    return [
+        'traceparent' => '00-traceid-spanid-01',
+        'tracestate' => 'vendor=value',
+    ];
+});
+```
+
+### SDK → CLI（アウトバウンド）
+
+以下のRPC呼び出しに自動的に`traceparent`/`tracestate`が注入されます:
+
+- `session.create` — セッション作成時
+- `session.resume` — セッション再開時
+- `session.send` — メッセージ送信時
+
+### CLI → SDK（インバウンド）
+
+CLIがツールを呼び出す際、ツールハンドラの`$invocation`配列にトレースコンテキストが含まれます:
+
+```php
+$session->registerTools([
+    [
+        'name' => 'my-tool',
+        'description' => 'My custom tool',
+        'handler' => function (array $args, array $invocation) {
+            // CLIのスパンからのトレースコンテキスト
+            $traceparent = $invocation['traceparent'] ?? null;
+            $tracestate = $invocation['tracestate'] ?? null;
+
+            // open-telemetry/apiがインストールされていれば
+            // コンテキストは自動的に復元され、
+            // ここで作成するスパンはCLIのスパンの子になります
+
+            return 'result';
+        },
+    ],
+]);
+```
+
+`open-telemetry/api`がインストールされている場合、ツールハンドラ実行中のOpenTelemetryコンテキストはCLIのスパンに自動的にリンクされます。明示的に`traceparent`を使う必要はありません。
+
+## 依存関係
+
+| パッケージ | 用途 |
+|---|---|
+| `open-telemetry/api` | 自動Trace Context伝搬（suggest、オプション） |
+| `open-telemetry/sdk` | トレースデータのエクスポート |
+
+`open-telemetry/api`はcomposer.jsonの`suggest`に含まれています。インストールされていなくても、SDK自体は正常に動作します。

--- a/src/Client.php
+++ b/src/Client.php
@@ -21,6 +21,7 @@ use Revolution\Copilot\Exceptions\JsonRpcException;
 use Revolution\Copilot\JsonRpc\JsonRpcClient;
 use Revolution\Copilot\Process\ProcessManager;
 use Revolution\Copilot\Rpc\ServerRpc;
+use Revolution\Copilot\Support\TraceContext;
 use Revolution\Copilot\Transport\TcpTransport;
 use Revolution\Copilot\Types\GetAuthStatusResponse;
 use Revolution\Copilot\Types\GetStatusResponse;
@@ -255,6 +256,7 @@ class Client implements CopilotClient
         ));
 
         $response = $this->rpcClient->request('session.create', array_filter([
+            ...TraceContext::get(),
             'sessionId' => $config['sessionId'] ?? null,
             'model' => $config['model'] ?? null,
             'reasoningEffort' => $config['reasoningEffort'] ?? null,
@@ -343,6 +345,7 @@ class Client implements CopilotClient
         ));
 
         $response = $this->rpcClient->request('session.resume', array_filter([
+            ...TraceContext::get(),
             'sessionId' => $sessionId,
             'reasoningEffort' => $config['reasoningEffort'] ?? null,
             'tools' => $toolsForRequest ?: null,

--- a/src/Concerns/Session/HasToolHandlers.php
+++ b/src/Concerns/Session/HasToolHandlers.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Revolution\Copilot\Concerns\Session;
 
 use Closure;
+use Revolution\Copilot\Support\TraceContext;
 use Revolution\Copilot\Types\Rpc\SessionToolsHandlePendingToolCallParams;
 use Revolution\Copilot\Types\ToolResultObject;
 use Throwable;
@@ -58,6 +59,8 @@ trait HasToolHandlers
     protected function executeToolAndRespond(string $requestId, string $toolName, ?string $toolCallId, mixed $arguments, Closure $handler, ?string $traceparent = null, ?string $tracestate = null): void
     {
         $fiber = new \Fiber(function () use ($requestId, $toolName, $toolCallId, $arguments, $handler, $traceparent, $tracestate): void {
+            $scope = TraceContext::restore($traceparent, $tracestate);
+
             try {
                 $invocation = [
                     'sessionId' => $this->sessionId,
@@ -111,6 +114,8 @@ trait HasToolHandlers
                 } catch (Throwable) {
                     // Connection lost or RPC error — nothing we can do
                 }
+            } finally {
+                TraceContext::detach($scope);
             }
         });
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -26,6 +26,7 @@ use Revolution\Copilot\Exceptions\SessionErrorException;
 use Revolution\Copilot\Exceptions\SessionTimeoutException;
 use Revolution\Copilot\JsonRpc\JsonRpcClient;
 use Revolution\Copilot\Rpc\SessionRpc;
+use Revolution\Copilot\Support\TraceContext;
 use Revolution\Copilot\Types\Rpc\SessionLogParams;
 use Revolution\Copilot\Types\Rpc\SessionModelSwitchToParams;
 use Revolution\Copilot\Types\SessionEvent;
@@ -123,12 +124,13 @@ class Session implements CopilotSession
      */
     public function send(string $prompt, ?array $attachments = null, ?string $mode = null): string
     {
-        $response = $this->client->request('session.send', [
+        $response = $this->client->request('session.send', array_filter([
+            ...TraceContext::get(),
             'sessionId' => $this->sessionId,
             'prompt' => $prompt,
             'attachments' => $attachments,
             'mode' => $mode,
-        ]);
+        ], fn ($v) => $v !== null));
 
         MessageSend::dispatch($this->sessionId, $response['messageId'] ?? '', $prompt, $attachments, $mode);
 

--- a/src/Support/TraceContext.php
+++ b/src/Support/TraceContext.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Revolution\Copilot\Support;
+
+use Closure;
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\Context\Context;
+
+/**
+ * W3C Trace Context helpers for OpenTelemetry propagation.
+ *
+ * Mirrors the Python SDK's `_telemetry.py` pattern:
+ * - `get()` extracts current trace context (like `get_trace_context()`)
+ * - `restore()` / `detach()` restore inbound context (like `trace_context()` context manager)
+ *
+ * When `open-telemetry/api` is installed, context propagation is automatic.
+ * Without it, these methods are safe no-ops.
+ */
+class TraceContext
+{
+    /**
+     * User-provided trace context provider callback.
+     *
+     * @var ?Closure(): array{traceparent?: string, tracestate?: string}
+     */
+    protected static ?Closure $provider = null;
+
+    /**
+     * Set a custom trace context provider.
+     *
+     * @param  ?Closure(): array{traceparent?: string, tracestate?: string}  $provider
+     */
+    public static function useProvider(?Closure $provider): void
+    {
+        static::$provider = $provider;
+    }
+
+    /**
+     * Get the current W3C Trace Context (traceparent/tracestate).
+     *
+     * If a custom provider is set, it is used. Otherwise, if `open-telemetry/api`
+     * is installed, the current context is extracted automatically.
+     *
+     * @return array{traceparent?: string, tracestate?: string}
+     */
+    public static function get(): array
+    {
+        if (static::$provider !== null) {
+            try {
+                return (static::$provider)();
+            } catch (\Throwable) {
+                return [];
+            }
+        }
+
+        return static::getFromOpenTelemetry();
+    }
+
+    /**
+     * Restore inbound W3C Trace Context as the active OpenTelemetry context.
+     *
+     * Returns a scope token that must be passed to `detach()` when done.
+     * Returns null if OpenTelemetry is not available or no traceparent is provided.
+     *
+     * @return mixed Scope token for detach(), or null
+     */
+    public static function restore(?string $traceparent, ?string $tracestate = null): mixed
+    {
+        if ($traceparent === null) {
+            return null;
+        }
+
+        if (! static::isOpenTelemetryAvailable()) {
+            return null;
+        }
+
+        try {
+            $carrier = ['traceparent' => $traceparent];
+            if ($tracestate !== null) {
+                $carrier['tracestate'] = $tracestate;
+            }
+
+            $propagator = Globals::propagator();
+            $context = $propagator->extract($carrier);
+
+            return Context::storage()->attach($context);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Detach a previously restored trace context scope.
+     */
+    public static function detach(mixed $scope): void
+    {
+        if ($scope === null) {
+            return;
+        }
+
+        try {
+            $scope->detach();
+        } catch (\Throwable) {
+            //
+        }
+    }
+
+    /**
+     * Extract trace context from OpenTelemetry API if available.
+     *
+     * @return array{traceparent?: string, tracestate?: string}
+     */
+    protected static function getFromOpenTelemetry(): array
+    {
+        if (! static::isOpenTelemetryAvailable()) {
+            return [];
+        }
+
+        try {
+            $carrier = [];
+            $propagator = Globals::propagator();
+            $propagator->inject($carrier);
+
+            $result = [];
+            if (isset($carrier['traceparent'])) {
+                $result['traceparent'] = $carrier['traceparent'];
+            }
+            if (isset($carrier['tracestate'])) {
+                $result['tracestate'] = $carrier['tracestate'];
+            }
+
+            return $result;
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Check if the OpenTelemetry API is available.
+     */
+    public static function isOpenTelemetryAvailable(): bool
+    {
+        return class_exists(Globals::class);
+    }
+}

--- a/tests/Feature/SessionTest.php
+++ b/tests/Feature/SessionTest.php
@@ -32,8 +32,6 @@ describe('Session', function () {
             ->with('session.send', [
                 'sessionId' => 'test-session',
                 'prompt' => 'Hello World',
-                'attachments' => null,
-                'mode' => null,
             ])
             ->once()
             ->andReturn(['messageId' => 'msg-123']);

--- a/tests/Unit/Support/TraceContextTest.php
+++ b/tests/Unit/Support/TraceContextTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Revolution\Copilot\Support\TraceContext;
+
+beforeEach(function () {
+    TraceContext::useProvider(null);
+});
+
+describe('TraceContext', function () {
+    it('returns empty array when no provider and no OpenTelemetry', function () {
+        // open-telemetry/api is not installed in test environment
+        expect(TraceContext::get())->toBe([]);
+    });
+
+    it('uses custom provider when set', function () {
+        TraceContext::useProvider(fn () => [
+            'traceparent' => '00-abc123-def456-01',
+            'tracestate' => 'vendor=value',
+        ]);
+
+        expect(TraceContext::get())->toBe([
+            'traceparent' => '00-abc123-def456-01',
+            'tracestate' => 'vendor=value',
+        ]);
+    });
+
+    it('returns empty array when provider throws', function () {
+        TraceContext::useProvider(fn () => throw new RuntimeException('provider error'));
+
+        expect(TraceContext::get())->toBe([]);
+    });
+
+    it('can clear provider', function () {
+        TraceContext::useProvider(fn () => ['traceparent' => '00-test-01']);
+
+        expect(TraceContext::get())->toHaveKey('traceparent');
+
+        TraceContext::useProvider(null);
+
+        expect(TraceContext::get())->toBe([]);
+    });
+
+    it('returns null scope when traceparent is null', function () {
+        expect(TraceContext::restore(null))->toBeNull();
+    });
+
+    it('returns null scope when OpenTelemetry not available', function () {
+        // open-telemetry/api is not installed in test environment
+        $scope = TraceContext::restore('00-abc123-def456-01', 'vendor=value');
+
+        expect($scope)->toBeNull();
+    });
+
+    it('detach handles null scope gracefully', function () {
+        TraceContext::detach(null);
+
+        expect(true)->toBeTrue(); // no exception thrown
+    });
+
+    it('reports OpenTelemetry as not available in test environment', function () {
+        expect(TraceContext::isOpenTelemetryAvailable())->toBeFalse();
+    });
+
+    it('provider can return partial context with only traceparent', function () {
+        TraceContext::useProvider(fn () => [
+            'traceparent' => '00-traceid-spanid-01',
+        ]);
+
+        $ctx = TraceContext::get();
+
+        expect($ctx)->toBe(['traceparent' => '00-traceid-spanid-01'])
+            ->and($ctx)->not->toHaveKey('tracestate');
+    });
+
+    it('provider can return empty array', function () {
+        TraceContext::useProvider(fn () => []);
+
+        expect(TraceContext::get())->toBe([]);
+    });
+});


### PR DESCRIPTION
Implement bidirectional W3C Trace Context propagation between the Laravel SDK and Copilot CLI, mirroring the official Python/Node.js SDKs.

Outbound (SDK → CLI):
- Inject traceparent/tracestate into session.create, session.resume, and session.send RPC params via TraceContext::get()

Inbound (CLI → SDK):
- Restore OpenTelemetry context in tool handlers via TraceContext::restore()/detach()

New files:
- src/Support/TraceContext.php - W3C Trace Context helpers
- tests/Unit/Support/TraceContextTest.php
- docs/jp/telemetry.md

Changes:
- config/copilot.php: Add telemetry configuration option
- composer.json: Add open-telemetry/api to suggest