### PR TITLE
Rename `usingListModels` to `listModelsUsing`

### DIFF
--- a/docs/jp/custom-providers.md
+++ b/docs/jp/custom-providers.md
@@ -110,13 +110,13 @@ $response = Copilot::run(
 
 BYOKモードでカスタムプロバイダーを使用している場合、`client->listModels()`がCLIサーバーではなくカスタムハンドラーを呼び出すように設定できます。
 
-`usingListModels()`メソッドを使って設定します。clientは初期化されやすいため、`listModels()`の前に常に`usingListModels()`を設定してください。
+`listModelsUsing()`メソッドを使って設定します。clientは初期化されやすいため、`listModels()`の前に常に`listModelsUsing()`を設定してください。
 
 ```php
 use Revolution\Copilot\Facades\Copilot;
 use Revolution\Copilot\Types\ModelInfo;
 
-$models = Copilot::client()->usingListModels(function (): array {
+$models = Copilot::client()->listModelsUsing(function (): array {
     // カスタムプロバイダーで利用可能なモデルを返す
     return [
         ['id' => 'my-model-1', 'name' => 'My Model 1', 'version' => '1.0'],
@@ -129,7 +129,7 @@ $models = Copilot::client()->usingListModels(function (): array {
 
 ```php
 // ハンドラーを解除してデフォルト動作（CLIサーバーに問い合わせ）に戻す
-$models = Copilot::client()->usingListModels(null)->listModels();
+$models = Copilot::client()->listModelsUsing(null)->listModels();
 ```
 
-`usingListModels()`が設定されている場合、`listModels()`はCLIサーバーへの接続を必要とせず、キャッシュも使用しません。
+`listModelsUsing()`が設定されている場合、`listModels()`はCLIサーバーへの接続を必要とせず、キャッシュも使用しません。

--- a/src/Concerns/Client/ManagesModels.php
+++ b/src/Concerns/Client/ManagesModels.php
@@ -29,10 +29,10 @@ trait ManagesModels
      * Pass null to remove the handler and revert to the default CLI server behaviour.
      *
      * ```php
-     * $models = Copilot::client()->usingListModels(fn() => [])->listModels();
+     * $models = Copilot::client()->listModelsUsing(fn() => [])->listModels();
      * ```
      */
-    public function usingListModels(?callable $callback = null): static
+    public function listModelsUsing(?callable $callback = null): static
     {
         $this->onListModels = $callback;
 
@@ -42,7 +42,7 @@ trait ManagesModels
     /**
      * List available models with their metadata.
      *
-     * If a handler was provided via usingListModels(), it is called instead of
+     * If a handler was provided via listModelsUsing(), it is called instead of
      * querying the CLI server. Useful in BYOK mode to return models available
      * from your custom provider.
      *

--- a/src/Contracts/CopilotClient.php
+++ b/src/Contracts/CopilotClient.php
@@ -78,7 +78,7 @@ interface CopilotClient
      * When set, listModels() calls this callback instead of querying the CLI server.
      * Pass null to remove the handler and revert to the default CLI server behaviour.
      */
-    public function usingListModels(?callable $callback = null): static;
+    public function listModelsUsing(?callable $callback = null): static;
 
     /**
      * List available models with their metadata.

--- a/tests/Feature/ClientTest.php
+++ b/tests/Feature/ClientTest.php
@@ -557,23 +557,23 @@ describe('Client', function () {
         fclose($stdout);
     });
 
-    it('usingListModels returns the client instance', function () {
+    it('listModelsUsing returns the client instance', function () {
         $client = new Client;
 
-        expect($client->usingListModels(fn () => []))->toBe($client);
+        expect($client->listModelsUsing(fn () => []))->toBe($client);
     });
 
-    it('usingListModels with null clears the handler', function () {
+    it('listModelsUsing with null clears the handler', function () {
         $client = new Client;
-        $client->usingListModels(fn () => []);
-        $client->usingListModels(null);
+        $client->listModelsUsing(fn () => []);
+        $client->listModelsUsing(null);
 
-        expect($client->usingListModels(null))->toBe($client);
+        expect($client->listModelsUsing(null))->toBe($client);
     });
 
-    it('listModels calls custom handler set via usingListModels', function () {
+    it('listModels calls custom handler set via listModelsUsing', function () {
         $client = new Client;
-        $client->usingListModels(fn () => [
+        $client->listModelsUsing(fn () => [
             [
                 'id' => 'my-model',
                 'name' => 'My Model',
@@ -594,7 +594,7 @@ describe('Client', function () {
 
     it('listModels returns empty array when custom handler returns empty', function () {
         $client = new Client;
-        $client->usingListModels(fn () => []);
+        $client->listModelsUsing(fn () => []);
 
         $models = $client->listModels();
 


### PR DESCRIPTION
Rename the custom model handler method from usingListModels() to listModelsUsing() for clarity and consistency. Updated the trait (ManagesModels), client contract (CopilotClient), tests (ClientTest) and documentation (docs/jp/custom-providers.md). Behavior is unchanged — pass a callable to set the handler or null to clear it; callers should switch to listModelsUsing().