### PR TITLE
Sync v1.0.0-beta.9

### DIFF
--- a/docs/develop/official-sdk-v1-ga-sync-plan.md
+++ b/docs/develop/official-sdk-v1-ga-sync-plan.md
@@ -213,3 +213,45 @@
   - `ClientTest` の `connect` handshake / legacy `ping` fallback regression
   - `ProviderConfig` / `SessionConfig` / `ResumeSessionConfig` rename alias tests
   - `SessionTest` の `getEvents()` regression
+
+## beta.9 同期メモ
+
+参照: https://github.com/github/copilot-sdk/releases/tag/v1.0.0-beta.9
+
+### 実装判断
+
+| 公式変更 | Laravel 版の対応 |
+| --- | --- |
+| `MessageOptions.agentMode` | `CopilotSession::send()` / `sendAndWait()` / `sendAndStream()` と `CopilotManager::run()` に `AgentMode|string|null $agentMode` を直接引数として追加する。Python SDK の `agent_mode=` と同じく per-message option として扱い、`SessionConfig` には入れない。wire key は `agentMode`。 |
+| `postToolUseFailure` hook | `SessionHooks::$onPostToolUseFailure` と hook dispatch map を追加する。`onPostToolUse` は成功時、`onPostToolUseFailure` は失敗時の hook として分離する。 |
+| tool filter precedence | `session.create` / `session.resume` に `toolFilterPrecedence: "excluded"` を送る。`availableTools` と `excludedTools` が両方ある場合は denylist が勝つ。docs/comments は source-qualified filter (`builtin:*`, `mcp:*`, `custom:*`) 前提に更新する。 |
+| `skipCustomInstructions` / `customAgentsLocalOnly` / `coauthorEnabled` / `manageScheduleEnabled` | `SessionConfig` / `ResumeSessionConfig` で round-trip し、create/resume 後に公式 Python / Node と同じく `session.options.update` で反映する。 |
+| `CopilotClientMode.Empty` | Laravel 版は今回未実装。公式では multi-tenant hardening と `availableTools` 必須検証を含むため、Laravel config/API と安全 default の設計判断が必要。現時点では `permission_approve` の default deny-all と明示的 tool filters を使う。 |
+| `ToolSet` helper | 今回未実装。Laravel 版では当面 `availableTools` / `excludedTools` に source-qualified string 配列を直接渡す。GA 前後に `Support\ToolSet` 相当を追加する余地がある。 |
+
+### 実装済み内容
+
+- `AgentMode` enum または文字列を `agentMode` 直接引数として渡せるようにした。
+  - `Copilot::run('...', agentMode: AgentMode::PLAN)`
+  - `$session->send('...', agentMode: 'autopilot')`
+- fake session / facade docblock / contracts も同じ signature に揃え、fake の recorded prompt に normalized `agentMode` を残すようにした。
+- `SessionHooks` に `onPostToolUseFailure` を追加し、`hooks.invoke` の `postToolUseFailure` を該当 handler へ dispatch するようにした。
+- `Client` の create/resume payload に `toolFilterPrecedence: "excluded"` を追加し、beta.9 option flags は session 作成/再開後の `session.options.update` で反映するようにした。
+- `SessionConfig` / `ResumeSessionConfig` に beta.9 option flags を追加した。既存 positional constructor 利用への影響を避けるため、新規 property は既存引数末尾に追加した。
+
+### beta.9 追加 tests
+
+- `SessionTest`
+  - `agentMode` enum/string の `session.send` wire regression
+  - `postToolUseFailure` hook dispatch regression
+- `CopilotManagerTest`
+  - `CopilotManager::run(..., agentMode: AgentMode::PLAN)`
+  - `CopilotManager::run(..., agentMode: 'shell')`
+- `CopilotFakeTest`
+  - fake run の `agentMode` recording
+- `SessionHooksTest`
+  - `onPostToolUseFailure` constructor/fromArray/toArray coverage
+- `SessionConfigTest` / `ResumeSessionConfigTest`
+  - beta.9 option flags の fromArray/toArray coverage
+- `ClientTest`
+  - create payload の `toolFilterPrecedence: "excluded"` と `session.options.update` 経由の beta.9 option flags

--- a/src/Client.php
+++ b/src/Client.php
@@ -312,6 +312,7 @@ class Client implements CopilotClient
             'systemMessage' => $config['systemMessage'] ?? null,
             'availableTools' => $config['availableTools'] ?? null,
             'excludedTools' => $config['excludedTools'] ?? null,
+            'toolFilterPrecedence' => 'excluded',
             'provider' => $config['provider'] ?? null,
             'requestPermission' => isset($config['onPermissionRequest']),
             'requestUserInput' => isset($config['onUserInputRequest']),
@@ -375,6 +376,8 @@ class Client implements CopilotClient
 
         $this->sessions[$sessionId] = $session;
 
+        $this->applyPostCreateOptionsPatch($sessionId, $session, $config);
+
         CreateSession::dispatch($session);
 
         return $session;
@@ -424,6 +427,10 @@ class Client implements CopilotClient
             'modelCapabilities' => $config['modelCapabilities'] ?? null,
             'tools' => $toolsForRequest ?: null,
             'commands' => $commandsForRequest,
+            'systemMessage' => $config['systemMessage'] ?? null,
+            'availableTools' => $config['availableTools'] ?? null,
+            'excludedTools' => $config['excludedTools'] ?? null,
+            'toolFilterPrecedence' => 'excluded',
             'provider' => $config['provider'] ?? null,
             'requestPermission' => isset($config['onPermissionRequest']),
             'requestUserInput' => isset($config['onUserInputRequest']),
@@ -488,9 +495,46 @@ class Client implements CopilotClient
 
         $this->sessions[$resumedSessionId] = $session;
 
+        $this->applyPostCreateOptionsPatch($resumedSessionId, $session, $config);
+
         ResumeSession::dispatch($session);
 
         return $session;
+    }
+
+    private function applyPostCreateOptionsPatch(string $sessionId, Session $session, array $config): void
+    {
+        $patch = array_filter([
+            'skipCustomInstructions' => $config['skipCustomInstructions'] ?? null,
+            'customAgentsLocalOnly' => $config['customAgentsLocalOnly'] ?? null,
+            'coauthorEnabled' => $config['coauthorEnabled'] ?? null,
+            'manageScheduleEnabled' => $config['manageScheduleEnabled'] ?? null,
+        ], fn ($value) => $value !== null);
+
+        if ($patch === []) {
+            return;
+        }
+
+        try {
+            $response = $this->rpcClient->request('session.options.update', [
+                'sessionId' => $sessionId,
+                ...$patch,
+            ]);
+
+            if (($response['success'] ?? true) === false) {
+                throw new RuntimeException('Failed to update session options');
+            }
+        } catch (Throwable $e) {
+            unset($this->sessions[$sessionId]);
+
+            try {
+                $session->disconnect();
+            } catch (Throwable $cleanupException) {
+                report($cleanupException);
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Concerns/Session/HasHooks.php
+++ b/src/Concerns/Session/HasHooks.php
@@ -45,6 +45,7 @@ trait HasHooks
         $handlerMap = [
             'preToolUse' => $this->hooks->onPreToolUse,
             'postToolUse' => $this->hooks->onPostToolUse,
+            'postToolUseFailure' => $this->hooks->onPostToolUseFailure,
             'preMcpToolCall' => $this->hooks->onPreMcpToolCall,
             'userPromptSubmitted' => $this->hooks->onUserPromptSubmitted,
             'sessionStart' => $this->hooks->onSessionStart,

--- a/src/Contracts/CopilotSession.php
+++ b/src/Contracts/CopilotSession.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Revolution\Copilot\Contracts;
 
 use Closure;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Enums\LogLevel;
 use Revolution\Copilot\Enums\ReasoningEffort;
 use Revolution\Copilot\Enums\SessionEventType;
@@ -91,12 +92,12 @@ interface CopilotSession
     /**
      * Send a message to this session.
      */
-    public function send(string $prompt, ?array $attachments = null, ?string $mode = null, ?array $requestHeaders = null): string;
+    public function send(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null): string;
 
     /**
      * Send a message and wait until the session becomes idle.
      */
-    public function sendAndWait(string $prompt, ?array $attachments = null, ?string $mode = null, ?float $timeout = null, ?array $requestHeaders = null): ?SessionEvent;
+    public function sendAndWait(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, ?float $timeout = null): ?SessionEvent;
 
     /**
      * Subscribe to events from this session.
@@ -122,7 +123,7 @@ interface CopilotSession
      *
      * @return iterable<SessionEvent>
      */
-    public function sendAndStream(string $prompt, ?array $attachments = null, ?string $mode = null, ?float $timeout = null, ?array $requestHeaders = null): iterable;
+    public function sendAndStream(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, ?float $timeout = null): iterable;
 
     /**
      * Yield events as a Generator until the session becomes idle.

--- a/src/Contracts/Factory.php
+++ b/src/Contracts/Factory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Revolution\Copilot\Contracts;
 
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Types\ResumeSessionConfig;
 use Revolution\Copilot\Types\SessionConfig;
 use Revolution\Copilot\Types\SessionEvent;
@@ -18,7 +19,7 @@ interface Factory
      * @param  ?string  $mode  Message delivery mode. "enqueue": Queue for processing after current turn (default). "immediate": Inject into current turn (steering). Omit for normal use.
      * @param  ?array<string, string>  $requestHeaders  Custom HTTP headers to include in outbound model requests for this turn.
      */
-    public function run(string $prompt, ?array $attachments = null, ?string $mode = null, ?array $requestHeaders = null, SessionConfig|array $config = []): ?SessionEvent;
+    public function run(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, SessionConfig|array $config = []): ?SessionEvent;
 
     /**
      * Start a session and execute a callback.

--- a/src/CopilotManager.php
+++ b/src/CopilotManager.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Traits\Macroable;
 use Revolution\Copilot\Contracts\CopilotClient;
 use Revolution\Copilot\Contracts\CopilotSession;
 use Revolution\Copilot\Contracts\Factory;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Support\PermissionHandler;
 use Revolution\Copilot\Testing\WithFake;
 use Revolution\Copilot\Types\ResumeSessionConfig;
@@ -48,12 +49,13 @@ class CopilotManager implements Factory
      * @param  string  $prompt  The prompt/message to send
      * @param  array<array{type: string, path: string, displayName?: string}>|null  $attachments  File or directory attachments. type: "file" | "directory"
      * @param  ?string  $mode  Message delivery mode. "enqueue": Queue for processing after current turn (default). "immediate": Inject into current turn (steering). Omit for normal use.
+     * @param  AgentMode|string|null  $agentMode  Per-message UI mode: "interactive", "plan", "autopilot", or "shell".
      * @param  ?array<string, string>  $requestHeaders  Custom HTTP headers to include in outbound model requests for this turn.
      */
-    public function run(string $prompt, ?array $attachments = null, ?string $mode = null, ?array $requestHeaders = null, SessionConfig|array $config = []): ?SessionEvent
+    public function run(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, SessionConfig|array $config = []): ?SessionEvent
     {
         if ($this->isFake()) {
-            return $this->fake->run($prompt, $attachments, $mode, $requestHeaders, $config);
+            return $this->fake->run($prompt, $attachments, $mode, $agentMode, $requestHeaders, $config);
         }
 
         return $this->start(
@@ -61,8 +63,9 @@ class CopilotManager implements Factory
                 prompt: $prompt,
                 attachments: $attachments,
                 mode: $mode,
-                timeout: $this->config['timeout'] ?? null,
+                agentMode: $agentMode,
                 requestHeaders: $requestHeaders,
+                timeout: $this->config['timeout'] ?? null,
             ),
             config: $config,
         );

--- a/src/Facades/Copilot.php
+++ b/src/Facades/Copilot.php
@@ -8,13 +8,14 @@ use Illuminate\Support\Facades\Facade;
 use Revolution\Copilot\Contracts\CopilotSession;
 use Revolution\Copilot\Contracts\Factory;
 use Revolution\Copilot\CopilotManager;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Testing\ResponseSequence;
 use Revolution\Copilot\Types\ResumeSessionConfig;
 use Revolution\Copilot\Types\SessionConfig;
 use Revolution\Copilot\Types\SessionEvent;
 
 /**
- * @method static SessionEvent|null run(string $prompt, ?array $attachments = null, ?string $mode = null, ?array $requestHeaders = null, SessionConfig|array $config = [])
+ * @method static SessionEvent|null run(string $prompt, ?array $attachments = null, ?string $mode = null, ?array $requestHeaders = null, SessionConfig|array $config = [], AgentMode|string|null $agentMode = null)
  * @method static mixed start(callable $callback, SessionConfig|ResumeSessionConfig|array $config = [], ?string $resume = null)
  * @method static iterable<SessionEvent> stream(callable $callback, SessionConfig|ResumeSessionConfig|array $config = [], ?string $resume = null)
  * @method static CopilotSession createSession(SessionConfig|array $config = [])

--- a/src/Session.php
+++ b/src/Session.php
@@ -19,6 +19,7 @@ use Revolution\Copilot\Concerns\Session\HasToolHandlers;
 use Revolution\Copilot\Concerns\Session\HasUiApi;
 use Revolution\Copilot\Concerns\Session\HasUserInputHandler;
 use Revolution\Copilot\Contracts\CopilotSession;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Enums\LogLevel;
 use Revolution\Copilot\Enums\ReasoningEffort;
 use Revolution\Copilot\Enums\SessionEventType;
@@ -138,11 +139,14 @@ class Session implements CopilotSession
      * @param  array<array{type: string, path: string, displayName?: string}>|null  $attachments  File or directory attachments. type: "file" | "directory"
      * @param  ?string  $mode  Message delivery mode. "enqueue": Queue for processing after current turn (default). "immediate": Inject into current turn (steering). Omit for normal use.
      * @param  ?array<string, string>  $requestHeaders  Custom HTTP headers to include in outbound model requests for this turn.
+     * @param  AgentMode|string|null  $agentMode  Per-message UI mode: "interactive", "plan", "autopilot", or "shell".
      *
      * @throws JsonRpcException
      */
-    public function send(string $prompt, ?array $attachments = null, ?string $mode = null, ?array $requestHeaders = null): string
+    public function send(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null): string
     {
+        $agentMode = $agentMode instanceof AgentMode ? $agentMode->value : $agentMode;
+
         $response = $this->client->request('session.send', array_filter([
             ...TraceContext::get(),
             'sessionId' => $this->sessionId,
@@ -150,6 +154,7 @@ class Session implements CopilotSession
             'attachments' => $attachments,
             'mode' => $mode,
             'requestHeaders' => $requestHeaders,
+            'agentMode' => $agentMode,
         ], fn ($v) => $v !== null));
 
         MessageSend::dispatch($this->sessionId, $response['messageId'] ?? '', $prompt, $attachments, $mode);
@@ -165,15 +170,16 @@ class Session implements CopilotSession
      * @param  ?string  $mode  Message delivery mode. "enqueue": Queue for processing after current turn (default). "immediate": Inject into current turn (steering). Omit for normal use.
      * @param  ?float  $timeout  Maximum time to wait for idle state, in seconds
      * @param  ?array<string, string>  $requestHeaders  Custom HTTP headers to include in outbound model requests for this turn.
+     * @param  AgentMode|string|null  $agentMode  Per-message UI mode: "interactive", "plan", "autopilot", or "shell".
      */
-    public function sendAndWait(string $prompt, ?array $attachments = null, ?string $mode = null, ?float $timeout = null, ?array $requestHeaders = null): ?SessionEvent
+    public function sendAndWait(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, ?float $timeout = null): ?SessionEvent
     {
         $timeout = $timeout ?? config('copilot.timeout', 60.0);
 
         $this->prepareWait();
 
         try {
-            $this->send($prompt, $attachments, $mode, $requestHeaders);
+            $this->send($prompt, $attachments, $mode, $requestHeaders, $agentMode);
             $this->wait($timeout);
 
             MessageSendAndWait::dispatch($this->sessionId, $this->waitLastAssistantMessage, $prompt, $attachments, $mode);
@@ -373,11 +379,12 @@ class Session implements CopilotSession
      * @param  ?string  $mode  Message delivery mode. "enqueue": Queue for processing after current turn (default). "immediate": Inject into current turn (steering). Omit for normal use.
      * @param  float|null  $timeout  Maximum time to wait for idle state, in seconds
      * @param  ?array<string, string>  $requestHeaders  Custom HTTP headers to include in outbound model requests for this turn.
+     * @param  AgentMode|string|null  $agentMode  Per-message UI mode: "interactive", "plan", "autopilot", or "shell".
      * @return iterable<SessionEvent>
      */
-    public function sendAndStream(string $prompt, ?array $attachments = null, ?string $mode = null, ?float $timeout = null, ?array $requestHeaders = null): iterable
+    public function sendAndStream(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, ?float $timeout = null): iterable
     {
-        $this->send($prompt, $attachments, $mode, $requestHeaders);
+        $this->send($prompt, $attachments, $mode, $requestHeaders, $agentMode);
 
         yield from $this->stream($timeout);
     }

--- a/src/Testing/CopilotFake.php
+++ b/src/Testing/CopilotFake.php
@@ -7,6 +7,7 @@ namespace Revolution\Copilot\Testing;
 use Illuminate\Support\Str;
 use Revolution\Copilot\Contracts\CopilotSession;
 use Revolution\Copilot\Contracts\Factory;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Facades\Copilot;
 use Revolution\Copilot\Types\ResumeSessionConfig;
 use Revolution\Copilot\Types\SessionConfig;
@@ -28,7 +29,7 @@ class CopilotFake implements Factory
     /**
      * Recorded prompts across all sessions.
      *
-     * @var array<array{prompt: string, attachments: ?array, mode: ?string}>
+     * @var array<array{prompt: string, attachments: ?array, mode: ?string, agentMode?: ?string}>
      */
     public array $recorded = [];
 
@@ -92,13 +93,14 @@ class CopilotFake implements Factory
     /**
      * Run a single prompt and return the response.
      */
-    public function run(string $prompt, ?array $attachments = null, ?string $mode = null, ?array $requestHeaders = null, SessionConfig|array $config = []): ?SessionEvent
+    public function run(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, SessionConfig|array $config = []): ?SessionEvent
     {
         return $this->start(
             fn (CopilotSession $session) => $session->sendAndWait(
                 prompt: $prompt,
                 attachments: $attachments,
                 mode: $mode,
+                agentMode: $agentMode,
                 requestHeaders: $requestHeaders,
             ),
             config: $config,
@@ -202,7 +204,7 @@ class CopilotFake implements Factory
     /**
      * Record a prompt.
      *
-     * @param  array{prompt: string, attachments: ?array, mode: ?string}  $record
+     * @param  array{prompt: string, attachments: ?array, mode: ?string, agentMode?: ?string}  $record
      */
     protected function recordPrompt(array $record): void
     {

--- a/src/Testing/FakeSession.php
+++ b/src/Testing/FakeSession.php
@@ -6,6 +6,7 @@ namespace Revolution\Copilot\Testing;
 
 use Closure;
 use Revolution\Copilot\Contracts\CopilotSession;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Enums\ElicitationAction;
 use Revolution\Copilot\Enums\LogLevel;
 use Revolution\Copilot\Enums\ReasoningEffort;
@@ -27,7 +28,7 @@ class FakeSession implements CopilotSession
     /**
      * Recorded prompts.
      *
-     * @var array<array{prompt: string, attachments: ?array, mode: ?string}>
+     * @var array<array{prompt: string, attachments: ?array, mode: ?string, agentMode?: ?string}>
      */
     protected array $recorded = [];
 
@@ -91,23 +92,25 @@ class FakeSession implements CopilotSession
         return '';
     }
 
-    public function send(string $prompt, ?array $attachments = null, ?string $mode = null, ?array $requestHeaders = null): string
+    public function send(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null): string
     {
         $this->recorded[] = [
             'prompt' => $prompt,
             'attachments' => $attachments,
             'mode' => $mode,
+            'agentMode' => $agentMode instanceof AgentMode ? $agentMode->value : $agentMode,
         ];
 
         return 'fake-message-id';
     }
 
-    public function sendAndWait(string $prompt, ?array $attachments = null, ?string $mode = null, ?float $timeout = null, ?array $requestHeaders = null): ?SessionEvent
+    public function sendAndWait(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, ?float $timeout = null): ?SessionEvent
     {
         $this->recorded[] = [
             'prompt' => $prompt,
             'attachments' => $attachments,
             'mode' => $mode,
+            'agentMode' => $agentMode instanceof AgentMode ? $agentMode->value : $agentMode,
         ];
 
         return $this->sequence->pop();
@@ -123,12 +126,13 @@ class FakeSession implements CopilotSession
         // No-op in fake
     }
 
-    public function sendAndStream(string $prompt, ?array $attachments = null, ?string $mode = null, ?float $timeout = null, ?array $requestHeaders = null): iterable
+    public function sendAndStream(string $prompt, ?array $attachments = null, ?string $mode = null, AgentMode|string|null $agentMode = null, ?array $requestHeaders = null, ?float $timeout = null): iterable
     {
         $this->recorded[] = [
             'prompt' => $prompt,
             'attachments' => $attachments,
             'mode' => $mode,
+            'agentMode' => $agentMode instanceof AgentMode ? $agentMode->value : $agentMode,
         ];
 
         $event = $this->sequence->pop();
@@ -156,7 +160,7 @@ class FakeSession implements CopilotSession
     /**
      * Get recorded prompts.
      *
-     * @return array<array{prompt: string, attachments: ?array, mode: ?string}>
+     * @return array<array{prompt: string, attachments: ?array, mode: ?string, agentMode?: ?string}>
      */
     public function recorded(): array
     {

--- a/src/Types/ResumeSessionConfig.php
+++ b/src/Types/ResumeSessionConfig.php
@@ -37,10 +37,10 @@ readonly class ResumeSessionConfig implements Arrayable
      *                            When the CLI has a TUI, each command appears as `/name` for the user to invoke.
      *                            Each entry should have 'name', 'handler', and optionally 'description'.
      * @param  SystemMessageConfig|array|null  $systemMessage  System message configuration. Controls how the system prompt is constructed.
-     * @param  ?array  $availableTools  List of tool names to allow. When specified, only these tools will be available.
-     *                                  Takes precedence over excludedTools.
-     * @param  ?array  $excludedTools  List of tool names to disable. All other tools remain available.
-     *                                 Ignored if availableTools is specified.
+     * @param  ?array  $availableTools  List of source-qualified tool filters to allow. When specified, only these tools will be available.
+     *                                  Examples: `builtin:*`, `builtin:bash`, `mcp:*`, `mcp:github-read_issue`, `custom:*`.
+     * @param  ?array  $excludedTools  List of source-qualified tool filters to disable. When both lists are set,
+     *                                 excludedTools wins (`toolFilterPrecedence: "excluded"`).
      * @param  ProviderConfig|array|null  $provider  Custom provider configuration (BYOK - Bring Your Own Key).
      *                                               When specified, uses the provided API endpoint instead of the Copilot API.
      * @param  ?Closure  $onPermissionRequest  Handler for permission requests from the server.
@@ -76,6 +76,10 @@ readonly class ResumeSessionConfig implements Arrayable
      * @param  ?array  $skillDirectories  Directories to load skills from
      * @param  ?array  $instructionDirectories  Additional directories to search for custom instruction files.
      * @param  ?array  $disabledSkills  List of skill names to disable
+     * @param  ?bool  $skipCustomInstructions  When true, custom instruction files are not loaded.
+     * @param  ?bool  $customAgentsLocalOnly  When true, only local custom agents are considered.
+     * @param  ?bool  $coauthorEnabled  Enables co-author integration for this session.
+     * @param  ?bool  $manageScheduleEnabled  Enables schedule management tools for this session.
      * @param  InfiniteSessionConfig|array|null  $infiniteSessions  Infinite session configuration for persistent workspaces and automatic compaction.
      *                                                              When enabled (default), sessions automatically manage context limits and persist state.
      *                                                              Set to `new InfiniteSessionConfig(enabled: false)` to disable.
@@ -142,6 +146,10 @@ readonly class ResumeSessionConfig implements Arrayable
         public ?bool $requestCanvasRenderer = null,
         public ?bool $requestExtensions = null,
         public ?Closure $onEvent = null,
+        public ?bool $skipCustomInstructions = null,
+        public ?bool $customAgentsLocalOnly = null,
+        public ?bool $coauthorEnabled = null,
+        public ?bool $manageScheduleEnabled = null,
     ) {}
 
     /**
@@ -220,6 +228,10 @@ readonly class ResumeSessionConfig implements Arrayable
             skillDirectories: $data['skillDirectories'] ?? null,
             instructionDirectories: $data['instructionDirectories'] ?? null,
             disabledSkills: $data['disabledSkills'] ?? null,
+            skipCustomInstructions: $data['skipCustomInstructions'] ?? null,
+            customAgentsLocalOnly: $data['customAgentsLocalOnly'] ?? null,
+            coauthorEnabled: $data['coauthorEnabled'] ?? null,
+            manageScheduleEnabled: $data['manageScheduleEnabled'] ?? null,
             infiniteSessions: $infiniteSessions,
             suppressResumeEvent: $data['suppressResumeEvent'] ?? $data['disableResume'] ?? null,
             continuePendingWork: $data['continuePendingWork'] ?? null,
@@ -300,6 +312,10 @@ readonly class ResumeSessionConfig implements Arrayable
             'skillDirectories' => $this->skillDirectories,
             'instructionDirectories' => $this->instructionDirectories,
             'disabledSkills' => $this->disabledSkills,
+            'skipCustomInstructions' => $this->skipCustomInstructions,
+            'customAgentsLocalOnly' => $this->customAgentsLocalOnly,
+            'coauthorEnabled' => $this->coauthorEnabled,
+            'manageScheduleEnabled' => $this->manageScheduleEnabled,
             'infiniteSessions' => $infiniteSessions,
             'suppressResumeEvent' => $this->suppressResumeEvent,
             'continuePendingWork' => $this->continuePendingWork,

--- a/src/Types/SessionConfig.php
+++ b/src/Types/SessionConfig.php
@@ -38,10 +38,10 @@ readonly class SessionConfig implements Arrayable
      *                            When the CLI has a TUI, each command appears as `/name` for the user to invoke.
      *                            Each entry should have 'name', 'handler', and optionally 'description'.
      * @param  SystemMessageConfig|array|null  $systemMessage  System message configuration. Controls how the system prompt is constructed.
-     * @param  ?array  $availableTools  List of tool names to allow. When specified, only these tools will be available.
-     *                                  Takes precedence over excludedTools.
-     * @param  ?array  $excludedTools  List of tool names to disable. All other tools remain available.
-     *                                 Ignored if availableTools is specified.
+     * @param  ?array  $availableTools  List of source-qualified tool filters to allow. When specified, only these tools will be available.
+     *                                  Examples: `builtin:*`, `builtin:bash`, `mcp:*`, `mcp:github-read_issue`, `custom:*`.
+     * @param  ?array  $excludedTools  List of source-qualified tool filters to disable. When both lists are set,
+     *                                 excludedTools wins (`toolFilterPrecedence: "excluded"`).
      * @param  ProviderConfig|array|null  $provider  Custom provider configuration (BYOK - Bring Your Own Key).
      *                                               When specified, uses the provided API endpoint instead of the Copilot API.
      * @param  ?Closure  $onPermissionRequest  Handler for permission requests from the server.
@@ -84,6 +84,10 @@ readonly class SessionConfig implements Arrayable
      * @param  ?array  $skillDirectories  Directories to load skills from
      * @param  ?array  $instructionDirectories  Additional directories to search for custom instruction files.
      * @param  ?array  $disabledSkills  List of skill names to disable
+     * @param  ?bool  $skipCustomInstructions  When true, custom instruction files are not loaded.
+     * @param  ?bool  $customAgentsLocalOnly  When true, only local custom agents are considered.
+     * @param  ?bool  $coauthorEnabled  Enables co-author integration for this session.
+     * @param  ?bool  $manageScheduleEnabled  Enables schedule management tools for this session.
      * @param  InfiniteSessionConfig|array|null  $infiniteSessions  Infinite session configuration for persistent workspaces and automatic compaction.
      *                                                              When enabled (default), sessions automatically manage context limits and persist state.
      *                                                              Set to `new InfiniteSessionConfig(enabled: false)` to disable.
@@ -158,6 +162,10 @@ readonly class SessionConfig implements Arrayable
         public ?bool $requestExtensions = null,
         public ExtensionInfo|array|null $extensionInfo = null,
         public ?Closure $onEvent = null,
+        public ?bool $skipCustomInstructions = null,
+        public ?bool $customAgentsLocalOnly = null,
+        public ?bool $coauthorEnabled = null,
+        public ?bool $manageScheduleEnabled = null,
     ) {}
 
     /**
@@ -245,6 +253,10 @@ readonly class SessionConfig implements Arrayable
             skillDirectories: $data['skillDirectories'] ?? null,
             instructionDirectories: $data['instructionDirectories'] ?? null,
             disabledSkills: $data['disabledSkills'] ?? null,
+            skipCustomInstructions: $data['skipCustomInstructions'] ?? null,
+            customAgentsLocalOnly: $data['customAgentsLocalOnly'] ?? null,
+            coauthorEnabled: $data['coauthorEnabled'] ?? null,
+            manageScheduleEnabled: $data['manageScheduleEnabled'] ?? null,
             infiniteSessions: $infiniteSessions,
             gitHubToken: $data['gitHubToken'] ?? null,
             remoteSession: $data['remoteSession'] ?? null,
@@ -329,6 +341,10 @@ readonly class SessionConfig implements Arrayable
             'skillDirectories' => $this->skillDirectories,
             'instructionDirectories' => $this->instructionDirectories,
             'disabledSkills' => $this->disabledSkills,
+            'skipCustomInstructions' => $this->skipCustomInstructions,
+            'customAgentsLocalOnly' => $this->customAgentsLocalOnly,
+            'coauthorEnabled' => $this->coauthorEnabled,
+            'manageScheduleEnabled' => $this->manageScheduleEnabled,
             'infiniteSessions' => $infiniteSessions,
             'gitHubToken' => $this->gitHubToken,
             'remoteSession' => $remoteSession,

--- a/src/Types/SessionHooks.php
+++ b/src/Types/SessionHooks.php
@@ -14,7 +14,8 @@ readonly class SessionHooks implements Arrayable
 {
     /**
      * @param  ?Closure  $onPreToolUse  Called before a tool is executed
-     * @param  ?Closure  $onPostToolUse  Called after a tool is executed
+     * @param  ?Closure  $onPostToolUse  Called after a tool is executed successfully
+     * @param  ?Closure  $onPostToolUseFailure  Called after a tool execution fails
      * @param  ?Closure  $onUserPromptSubmitted  Called when the user submits a prompt
      * @param  ?Closure  $onSessionStart  Called when a session starts
      * @param  ?Closure  $onSessionEnd  Called when a session ends
@@ -24,6 +25,7 @@ readonly class SessionHooks implements Arrayable
     public function __construct(
         public ?Closure $onPreToolUse = null,
         public ?Closure $onPostToolUse = null,
+        public ?Closure $onPostToolUseFailure = null,
         public ?Closure $onUserPromptSubmitted = null,
         public ?Closure $onSessionStart = null,
         public ?Closure $onSessionEnd = null,
@@ -39,6 +41,7 @@ readonly class SessionHooks implements Arrayable
         return new self(
             onPreToolUse: $data['onPreToolUse'] ?? null,
             onPostToolUse: $data['onPostToolUse'] ?? null,
+            onPostToolUseFailure: $data['onPostToolUseFailure'] ?? null,
             onUserPromptSubmitted: $data['onUserPromptSubmitted'] ?? null,
             onSessionStart: $data['onSessionStart'] ?? null,
             onSessionEnd: $data['onSessionEnd'] ?? null,
@@ -55,6 +58,7 @@ readonly class SessionHooks implements Arrayable
         return array_filter([
             'onPreToolUse' => $this->onPreToolUse,
             'onPostToolUse' => $this->onPostToolUse,
+            'onPostToolUseFailure' => $this->onPostToolUseFailure,
             'onUserPromptSubmitted' => $this->onUserPromptSubmitted,
             'onSessionStart' => $this->onSessionStart,
             'onSessionEnd' => $this->onSessionEnd,

--- a/tests/Feature/ClientTest.php
+++ b/tests/Feature/ClientTest.php
@@ -409,6 +409,67 @@ describe('Client', function () {
         expect($session)->toBe($mockSession);
     });
 
+    it('createSession sends beta9 tool precedence and applies option flags', function () {
+        $mockStdioTransport = Mockery::mock(StdioTransport::class);
+
+        $mockProcessManager = Mockery::mock(ProcessManager::class);
+        $mockProcessManager->shouldReceive('start')->once();
+        $mockProcessManager->shouldReceive('getStdioTransport')->andReturn($mockStdioTransport);
+
+        $mockRpcClient = Mockery::mock(JsonRpcClient::class);
+        $mockRpcClient->shouldReceive('start')->once();
+        $mockRpcClient->shouldReceive('setNotificationHandler')->once();
+        $mockRpcClient->shouldReceive('setRequestHandler')->times(4);
+        $mockRpcClient->shouldReceive('request')
+            ->with('connect', [])
+            ->once()
+            ->andReturn(['version' => '', 'protocolVersion' => Protocol::version()]);
+        $mockRpcClient->shouldReceive('request')
+            ->with('session.create', Mockery::on(fn ($params) => ($params['availableTools'] ?? null) === ['builtin:*']
+                && ($params['excludedTools'] ?? null) === ['mcp:github-delete_repository']
+                && ($params['toolFilterPrecedence'] ?? null) === 'excluded'
+                && ! array_key_exists('skipCustomInstructions', $params)
+                && ! array_key_exists('customAgentsLocalOnly', $params)
+                && ! array_key_exists('coauthorEnabled', $params)
+                && ! array_key_exists('manageScheduleEnabled', $params)))
+            ->once()
+            ->andReturn(['sessionId' => 'test-session-123']);
+        $mockRpcClient->shouldReceive('request')
+            ->with('session.options.update', [
+                'sessionId' => 'test-session-123',
+                'skipCustomInstructions' => true,
+                'customAgentsLocalOnly' => true,
+                'coauthorEnabled' => false,
+                'manageScheduleEnabled' => true,
+            ])
+            ->once()
+            ->andReturn(['success' => true]);
+
+        $mockSession = Mockery::mock(Session::class);
+        $mockSession->shouldReceive('registerTools')->once()->with([]);
+        $mockSession->shouldReceive('registerCommands')->once()->with([]);
+        $mockSession->shouldReceive('setCapabilities')->once()->with(null);
+        $mockSession->shouldReceive('registerPermissionHandler')->once();
+
+        $this->app->bind(ProcessManager::class, fn () => $mockProcessManager);
+        $this->app->bind(JsonRpcClient::class, fn () => $mockRpcClient);
+        $this->app->bind(Session::class, fn () => $mockSession);
+
+        $client = new Client;
+        $client->start();
+        $session = $client->createSession([
+            'availableTools' => ['builtin:*'],
+            'excludedTools' => ['mcp:github-delete_repository'],
+            'skipCustomInstructions' => true,
+            'customAgentsLocalOnly' => true,
+            'coauthorEnabled' => false,
+            'manageScheduleEnabled' => true,
+            'onPermissionRequest' => PermissionHandler::approveAll(),
+        ]);
+
+        expect($session)->toBe($mockSession);
+    });
+
     it('resumeSession sends only name/description for commands in RPC request', function () {
         Event::fake();
 
@@ -568,6 +629,16 @@ describe('Client', function () {
             ->with('session.resume', Mockery::any())
             ->once()
             ->andReturn(['sessionId' => 'test-session-123']);
+        $mockRpcClient->shouldReceive('request')
+            ->with('session.options.update', [
+                'sessionId' => 'test-session-123',
+                'skipCustomInstructions' => true,
+                'customAgentsLocalOnly' => true,
+                'coauthorEnabled' => false,
+                'manageScheduleEnabled' => true,
+            ])
+            ->once()
+            ->andReturn(['success' => true]);
 
         $mockSession = Mockery::mock(Session::class);
         $mockSession->shouldReceive('registerTools')->once()->with([]);
@@ -583,6 +654,10 @@ describe('Client', function () {
         $client->start();
         $session = $client->resumeSession('test-session-123', [
             'onPermissionRequest' => PermissionHandler::approveAll(),
+            'skipCustomInstructions' => true,
+            'customAgentsLocalOnly' => true,
+            'coauthorEnabled' => false,
+            'manageScheduleEnabled' => true,
         ]);
 
         expect($session)->toBe($mockSession);

--- a/tests/Feature/CopilotFakeTest.php
+++ b/tests/Feature/CopilotFakeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Revolution\Copilot\Contracts\CopilotSession;
 use Revolution\Copilot\CopilotManager;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Enums\LogLevel;
 use Revolution\Copilot\Exceptions\StrayRequestException;
 use Revolution\Copilot\Facades\Copilot;
@@ -32,6 +33,17 @@ describe('Copilot::fake()', function () {
         $response = Copilot::run('What is 6 * 7?');
 
         expect((string) $response)->toBe('42');
+    });
+
+    it('records agent mode from run', function () {
+        Copilot::fake('Planned');
+
+        $response = Copilot::run('Plan this', agentMode: AgentMode::PLAN);
+        $recorded = Copilot::recorded();
+
+        expect($response?->content())->toBe('Planned')
+            ->and($recorded)->toHaveCount(1)
+            ->and($recorded[0]['agentMode'])->toBe('plan');
     });
 
     it('returns CopilotManager instance', function () {

--- a/tests/Feature/CopilotManagerTest.php
+++ b/tests/Feature/CopilotManagerTest.php
@@ -7,6 +7,7 @@ use Revolution\Copilot\Client;
 use Revolution\Copilot\Contracts\CopilotClient;
 use Revolution\Copilot\Contracts\CopilotSession;
 use Revolution\Copilot\CopilotManager;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Facades\Copilot;
 use Revolution\Copilot\Types\SessionEvent;
 
@@ -241,7 +242,7 @@ describe('CopilotManager', function () {
 
         $mockSession = Mockery::mock(CopilotSession::class);
         $mockSession->shouldReceive('sendAndWait')
-            ->with('test prompt', null, null, 60.0, null)
+            ->with('test prompt', null, null, null, null, 60.0)
             ->once()
             ->andReturn($mockEvent);
         $mockSession->shouldReceive('disconnect')->once();
@@ -265,7 +266,7 @@ describe('CopilotManager', function () {
     it('run uses configured timeout', function () {
         $mockSession = Mockery::mock(CopilotSession::class);
         $mockSession->shouldReceive('sendAndWait')
-            ->with('prompt', null, null, 120.0, null) // Custom timeout
+            ->with('prompt', null, null, null, null, 120.0) // Custom timeout
             ->once()
             ->andReturn(null);
         $mockSession->shouldReceive('disconnect')->once();
@@ -288,7 +289,7 @@ describe('CopilotManager', function () {
 
         $mockSession = Mockery::mock(CopilotSession::class);
         $mockSession->shouldReceive('sendAndWait')
-            ->with('prompt', null, null, 120.0, $requestHeaders)
+            ->with('prompt', null, null, null, $requestHeaders, 120.0)
             ->once()
             ->andReturn(null);
         $mockSession->shouldReceive('disconnect')->once();
@@ -302,6 +303,48 @@ describe('CopilotManager', function () {
 
         $manager = new CopilotManager(['timeout' => 120.0]);
         $manager->run('prompt', requestHeaders: $requestHeaders);
+
+        $manager->stop();
+    });
+
+    it('run passes agent mode to sendAndWait', function () {
+        $mockSession = Mockery::mock(CopilotSession::class);
+        $mockSession->shouldReceive('sendAndWait')
+            ->with('prompt', null, null, AgentMode::PLAN, null, 120.0)
+            ->once()
+            ->andReturn(null);
+        $mockSession->shouldReceive('disconnect')->once();
+
+        $mockClient = Mockery::mock(CopilotClient::class);
+        $mockClient->shouldReceive('start')->once();
+        $mockClient->shouldReceive('createSession')->once()->andReturn($mockSession);
+        $mockClient->shouldReceive('stop')->andReturn([]);
+
+        $this->app->bind(Client::class, fn () => $mockClient);
+
+        $manager = new CopilotManager(['timeout' => 120.0]);
+        $manager->run('prompt', agentMode: AgentMode::PLAN);
+
+        $manager->stop();
+    });
+
+    it('run accepts agent mode string', function () {
+        $mockSession = Mockery::mock(CopilotSession::class);
+        $mockSession->shouldReceive('sendAndWait')
+            ->with('prompt', null, null, 'shell', null, 120.0)
+            ->once()
+            ->andReturn(null);
+        $mockSession->shouldReceive('disconnect')->once();
+
+        $mockClient = Mockery::mock(CopilotClient::class);
+        $mockClient->shouldReceive('start')->once();
+        $mockClient->shouldReceive('createSession')->once()->andReturn($mockSession);
+        $mockClient->shouldReceive('stop')->andReturn([]);
+
+        $this->app->bind(Client::class, fn () => $mockClient);
+
+        $manager = new CopilotManager(['timeout' => 120.0]);
+        $manager->run('prompt', agentMode: 'shell');
 
         $manager->stop();
     });

--- a/tests/Feature/FakeSessionUiTest.php
+++ b/tests/Feature/FakeSessionUiTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Revolution\Copilot\Contracts\CopilotSession;
 use Revolution\Copilot\Enums\ElicitationAction;
 use Revolution\Copilot\Facades\Copilot;
-use Revolution\Copilot\Types\InputOptions;
 use Revolution\Copilot\Types\Rpc\UIElicitationResponse;
 use Revolution\Copilot\Types\SessionCapabilities;
 use Revolution\Copilot\Types\UiInputOptions;

--- a/tests/Feature/SessionTest.php
+++ b/tests/Feature/SessionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Revolt\EventLoop;
+use Revolution\Copilot\Enums\AgentMode;
 use Revolution\Copilot\Enums\SessionEventType;
 use Revolution\Copilot\Exceptions\SessionErrorException;
 use Revolution\Copilot\Exceptions\SessionTimeoutException;
@@ -58,6 +59,40 @@ describe('Session', function () {
         $messageId = $session->send('prompt', [['type' => 'file', 'path' => '/test.txt']], 'plan');
 
         expect($messageId)->toBe('msg-456');
+    });
+
+    it('send accepts agent mode enum', function () {
+        $mockClient = Mockery::mock(JsonRpcClient::class);
+        $mockClient->shouldReceive('request')
+            ->with('session.send', [
+                'sessionId' => 'test-session',
+                'prompt' => 'prompt',
+                'agentMode' => 'plan',
+            ])
+            ->once()
+            ->andReturn(['messageId' => 'msg-789']);
+
+        $session = new Session('test-session', $mockClient);
+        $messageId = $session->send('prompt', agentMode: AgentMode::PLAN);
+
+        expect($messageId)->toBe('msg-789');
+    });
+
+    it('send accepts agent mode string', function () {
+        $mockClient = Mockery::mock(JsonRpcClient::class);
+        $mockClient->shouldReceive('request')
+            ->with('session.send', [
+                'sessionId' => 'test-session',
+                'prompt' => 'prompt',
+                'agentMode' => 'autopilot',
+            ])
+            ->once()
+            ->andReturn(['messageId' => 'msg-790']);
+
+        $session = new Session('test-session', $mockClient);
+        $messageId = $session->send('prompt', agentMode: 'autopilot');
+
+        expect($messageId)->toBe('msg-790');
     });
 
     it('on registers event handler', function () {
@@ -230,6 +265,35 @@ describe('Session', function () {
         $session->dispatchEvent(SessionEvent::fromArray(['type' => 'session.idle']));
 
         expect($secondHandlerCalled)->toBeTrue();
+    });
+
+    it('invokes post tool use failure hook', function () {
+        $mockClient = Mockery::mock(JsonRpcClient::class);
+        $session = new Session('test-session', $mockClient);
+
+        $called = false;
+        $receivedInput = null;
+        $receivedContext = null;
+
+        $session->registerHooks([
+            'onPostToolUseFailure' => function ($input, $context) use (&$called, &$receivedInput, &$receivedContext) {
+                $called = true;
+                $receivedInput = $input;
+                $receivedContext = $context;
+
+                return ['additionalContext' => 'Prefer a safer command'];
+            },
+        ]);
+
+        $result = $session->handleHooksInvoke('postToolUseFailure', [
+            'toolName' => 'bash',
+            'error' => 'failed',
+        ]);
+
+        expect($called)->toBeTrue()
+            ->and($receivedInput)->toBe(['toolName' => 'bash', 'error' => 'failed'])
+            ->and($receivedContext)->toBe(['sessionId' => 'test-session'])
+            ->and($result)->toBe(['additionalContext' => 'Prefer a safer command']);
     });
 
     it('registerTools stores tool handlers', function () {

--- a/tests/Unit/Concerns/Session/HasUiApiTest.php
+++ b/tests/Unit/Concerns/Session/HasUiApiTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 use Revolution\Copilot\Enums\ElicitationAction;
 use Revolution\Copilot\JsonRpc\JsonRpcClient;
 use Revolution\Copilot\Session;
-use Revolution\Copilot\Types\UiInputOptions;
 use Revolution\Copilot\Types\Rpc\UIElicitationResponse;
 use Revolution\Copilot\Types\SessionCapabilities;
+use Revolution\Copilot\Types\UiInputOptions;
 
 describe('HasUiApi', function () {
     it('returns empty capabilities by default', function () {

--- a/tests/Unit/Types/ResumeSessionConfigTest.php
+++ b/tests/Unit/Types/ResumeSessionConfigTest.php
@@ -41,6 +41,10 @@ describe('ResumeSessionConfig', function () {
             'skillDirectories' => ['/path/to/skills'],
             'instructionDirectories' => ['/path/to/instructions'],
             'disabledSkills' => ['skill1'],
+            'skipCustomInstructions' => true,
+            'customAgentsLocalOnly' => true,
+            'coauthorEnabled' => false,
+            'manageScheduleEnabled' => true,
             'infiniteSessions' => new InfiniteSessionConfig(enabled: true, backgroundCompactionThreshold: 0.80, bufferExhaustionThreshold: 0.95),
             'suppressResumeEvent' => true,
             'agent' => 'reviewer',
@@ -67,6 +71,10 @@ describe('ResumeSessionConfig', function () {
             ->and($config->skillDirectories)->toBe(['/path/to/skills'])
             ->and($config->instructionDirectories)->toBe(['/path/to/instructions'])
             ->and($config->disabledSkills)->toBe(['skill1'])
+            ->and($config->skipCustomInstructions)->toBeTrue()
+            ->and($config->customAgentsLocalOnly)->toBeTrue()
+            ->and($config->coauthorEnabled)->toBeFalse()
+            ->and($config->manageScheduleEnabled)->toBeTrue()
             ->and($config->agent)->toBe('reviewer');
     });
 
@@ -87,6 +95,10 @@ describe('ResumeSessionConfig', function () {
             ->and($config->skillDirectories)->toBeNull()
             ->and($config->instructionDirectories)->toBeNull()
             ->and($config->disabledSkills)->toBeNull()
+            ->and($config->skipCustomInstructions)->toBeNull()
+            ->and($config->customAgentsLocalOnly)->toBeNull()
+            ->and($config->coauthorEnabled)->toBeNull()
+            ->and($config->manageScheduleEnabled)->toBeNull()
             ->and($config->agent)->toBeNull();
     });
 
@@ -137,6 +149,10 @@ describe('ResumeSessionConfig', function () {
             customAgents: [['name' => 'agent1']],
             skillDirectories: ['/skills'],
             disabledSkills: ['skill1'],
+            skipCustomInstructions: true,
+            customAgentsLocalOnly: true,
+            coauthorEnabled: false,
+            manageScheduleEnabled: true,
             infiniteSessions: new InfiniteSessionConfig(enabled: true, backgroundCompactionThreshold: 0.80, bufferExhaustionThreshold: 0.95),
             suppressResumeEvent: false,
             agent: 'reviewer',
@@ -160,6 +176,10 @@ describe('ResumeSessionConfig', function () {
             ->and($array['customAgents'])->toBe([['name' => 'agent1']])
             ->and($array['skillDirectories'])->toBe(['/skills'])
             ->and($array['disabledSkills'])->toBe(['skill1'])
+            ->and($array['skipCustomInstructions'])->toBeTrue()
+            ->and($array['customAgentsLocalOnly'])->toBeTrue()
+            ->and($array['coauthorEnabled'])->toBeFalse()
+            ->and($array['manageScheduleEnabled'])->toBeTrue()
             ->and($array['agent'])->toBe('reviewer');
     });
 

--- a/tests/Unit/Types/SessionConfigTest.php
+++ b/tests/Unit/Types/SessionConfigTest.php
@@ -41,6 +41,10 @@ describe('SessionConfig', function () {
             'skillDirectories' => ['/path/to/skills'],
             'instructionDirectories' => ['/path/to/instructions'],
             'disabledSkills' => ['skill1'],
+            'skipCustomInstructions' => true,
+            'customAgentsLocalOnly' => true,
+            'coauthorEnabled' => false,
+            'manageScheduleEnabled' => true,
             'infiniteSessions' => ['enabled' => true, 'backgroundCompactionThreshold' => 0.80],
             'agent' => 'reviewer',
         ]);
@@ -68,6 +72,10 @@ describe('SessionConfig', function () {
             ->and($config->skillDirectories)->toBe(['/path/to/skills'])
             ->and($config->instructionDirectories)->toBe(['/path/to/instructions'])
             ->and($config->disabledSkills)->toBe(['skill1'])
+            ->and($config->skipCustomInstructions)->toBeTrue()
+            ->and($config->customAgentsLocalOnly)->toBeTrue()
+            ->and($config->coauthorEnabled)->toBeFalse()
+            ->and($config->manageScheduleEnabled)->toBeTrue()
             ->and($config->infiniteSessions)->toBeInstanceOf(InfiniteSessionConfig::class)
             ->and($config->infiniteSessions->enabled)->toBeTrue()
             ->and($config->infiniteSessions->backgroundCompactionThreshold)->toBe(0.80)
@@ -97,6 +105,10 @@ describe('SessionConfig', function () {
             ->and($config->skillDirectories)->toBeNull()
             ->and($config->instructionDirectories)->toBeNull()
             ->and($config->disabledSkills)->toBeNull()
+            ->and($config->skipCustomInstructions)->toBeNull()
+            ->and($config->customAgentsLocalOnly)->toBeNull()
+            ->and($config->coauthorEnabled)->toBeNull()
+            ->and($config->manageScheduleEnabled)->toBeNull()
             ->and($config->infiniteSessions)->toBeNull()
             ->and($config->agent)->toBeNull();
     });
@@ -148,6 +160,10 @@ describe('SessionConfig', function () {
             customAgents: [['name' => 'agent1']],
             skillDirectories: ['/skills'],
             disabledSkills: ['skill1'],
+            skipCustomInstructions: true,
+            customAgentsLocalOnly: true,
+            coauthorEnabled: false,
+            manageScheduleEnabled: true,
             infiniteSessions: new InfiniteSessionConfig(enabled: false),
             agent: 'reviewer',
         );
@@ -175,6 +191,10 @@ describe('SessionConfig', function () {
             ->and($array['customAgents'])->toBe([['name' => 'agent1']])
             ->and($array['skillDirectories'])->toBe(['/skills'])
             ->and($array['disabledSkills'])->toBe(['skill1'])
+            ->and($array['skipCustomInstructions'])->toBeTrue()
+            ->and($array['customAgentsLocalOnly'])->toBeTrue()
+            ->and($array['coauthorEnabled'])->toBeFalse()
+            ->and($array['manageScheduleEnabled'])->toBeTrue()
             ->and($array['infiniteSessions'])->toBe(['enabled' => false])
             ->and($array['agent'])->toBe('reviewer');
     });

--- a/tests/Unit/Types/SessionHooksTest.php
+++ b/tests/Unit/Types/SessionHooksTest.php
@@ -9,6 +9,7 @@ describe('SessionHooks', function () {
     it('can be created with all hooks', function () {
         $preToolUse = fn () => null;
         $postToolUse = fn () => null;
+        $postToolUseFailure = fn () => null;
         $userPromptSubmitted = fn () => null;
         $sessionStart = fn () => null;
         $sessionEnd = fn () => null;
@@ -18,6 +19,7 @@ describe('SessionHooks', function () {
         $hooks = new SessionHooks(
             onPreToolUse: $preToolUse,
             onPostToolUse: $postToolUse,
+            onPostToolUseFailure: $postToolUseFailure,
             onUserPromptSubmitted: $userPromptSubmitted,
             onSessionStart: $sessionStart,
             onSessionEnd: $sessionEnd,
@@ -27,6 +29,7 @@ describe('SessionHooks', function () {
 
         expect($hooks->onPreToolUse)->toBe($preToolUse)
             ->and($hooks->onPostToolUse)->toBe($postToolUse)
+            ->and($hooks->onPostToolUseFailure)->toBe($postToolUseFailure)
             ->and($hooks->onUserPromptSubmitted)->toBe($userPromptSubmitted)
             ->and($hooks->onSessionStart)->toBe($sessionStart)
             ->and($hooks->onSessionEnd)->toBe($sessionEnd)
@@ -39,6 +42,7 @@ describe('SessionHooks', function () {
 
         expect($hooks->onPreToolUse)->toBeNull()
             ->and($hooks->onPostToolUse)->toBeNull()
+            ->and($hooks->onPostToolUseFailure)->toBeNull()
             ->and($hooks->onUserPromptSubmitted)->toBeNull()
             ->and($hooks->onSessionStart)->toBeNull()
             ->and($hooks->onSessionEnd)->toBeNull()
@@ -57,20 +61,24 @@ describe('SessionHooks', function () {
 
         expect($hooks->onPreToolUse)->toBe($preToolUse)
             ->and($hooks->onPostToolUse)->toBeNull()
+            ->and($hooks->onPostToolUseFailure)->toBeNull()
             ->and($hooks->onSessionEnd)->toBe($sessionEnd);
     });
 
     it('can be created from array', function () {
         $preToolUse = fn () => null;
+        $postToolUseFailure = fn () => null;
         $errorOccurred = fn () => null;
 
         $hooks = SessionHooks::fromArray([
             'onPreToolUse' => $preToolUse,
+            'onPostToolUseFailure' => $postToolUseFailure,
             'onErrorOccurred' => $errorOccurred,
         ]);
 
         expect($hooks->onPreToolUse)->toBe($preToolUse)
             ->and($hooks->onPostToolUse)->toBeNull()
+            ->and($hooks->onPostToolUseFailure)->toBe($postToolUseFailure)
             ->and($hooks->onErrorOccurred)->toBe($errorOccurred);
     });
 
@@ -79,6 +87,7 @@ describe('SessionHooks', function () {
 
         expect($hooks->onPreToolUse)->toBeNull()
             ->and($hooks->onPostToolUse)->toBeNull()
+            ->and($hooks->onPostToolUseFailure)->toBeNull()
             ->and($hooks->onUserPromptSubmitted)->toBeNull()
             ->and($hooks->onSessionStart)->toBeNull()
             ->and($hooks->onSessionEnd)->toBeNull()
@@ -89,18 +98,22 @@ describe('SessionHooks', function () {
     it('can convert to array with all hooks', function () {
         $preToolUse = fn () => 'pre';
         $postToolUse = fn () => 'post';
+        $postToolUseFailure = fn () => 'failure';
 
         $hooks = new SessionHooks(
             onPreToolUse: $preToolUse,
             onPostToolUse: $postToolUse,
+            onPostToolUseFailure: $postToolUseFailure,
         );
 
         $array = $hooks->toArray();
 
         expect($array)->toHaveKey('onPreToolUse')
             ->and($array)->toHaveKey('onPostToolUse')
+            ->and($array)->toHaveKey('onPostToolUseFailure')
             ->and($array['onPreToolUse'])->toBe($preToolUse)
-            ->and($array['onPostToolUse'])->toBe($postToolUse);
+            ->and($array['onPostToolUse'])->toBe($postToolUse)
+            ->and($array['onPostToolUseFailure'])->toBe($postToolUseFailure);
     });
 
     it('filters null values in toArray', function () {


### PR DESCRIPTION
- Updated the `run` method in `Copilot` to accept an optional `agentMode` parameter.
- Enhanced the `send`, `sendAndWait`, and `sendAndStream` methods in `Session` to include `agentMode`.
- Modified `CopilotFake` and `FakeSession` to record and handle `agentMode`.
- Introduced new configuration options in `ResumeSessionConfig` and `SessionConfig` for managing custom instructions and agent behavior.
- Added tests to verify the correct handling of `agentMode` in various scenarios, including session creation and prompt handling.
- Updated session hooks to include a failure callback for tool execution.