### PR TITLE
Add tool `defer` option to Tool and Client

### DIFF
--- a/docs/jp/tools.md
+++ b/docs/jp/tools.md
@@ -63,6 +63,7 @@ Artisan::command('copilot:tools', function () {
                 },
                 overridesBuiltInTool: false,
                 skipPermission: false, // trueにするとパーミッションプロンプトなしで実行
+                defer: 'auto', // ツールを常にプリロードするのではなく、遅延ロード（ツール検索による遅延ロード）するかどうかを制御します。`"auto"` の場合、ツールは遅延ロードされ、ツール検索によって表示されます。`"never"` の場合、ツールは常にプリロードされます。オプション。デフォルトは `"auto" です。
             ),
         ],
     );

--- a/src/Client.php
+++ b/src/Client.php
@@ -292,6 +292,7 @@ class Client implements CopilotClient
             'parameters' => $tool['parameters'] ?? null,
             'overridesBuiltInTool' => $tool['overridesBuiltInTool'] ?? null,
             'skipPermission' => $tool['skipPermission'] ?? null,
+            'defer' => $tool['defer'] ?? null,
         ], fn ($v) => $v !== null), $tools);
 
         $commands = $config['commands'] ?? [];
@@ -435,6 +436,7 @@ class Client implements CopilotClient
             'parameters' => $tool['parameters'] ?? null,
             'overridesBuiltInTool' => $tool['overridesBuiltInTool'] ?? null,
             'skipPermission' => $tool['skipPermission'] ?? null,
+            'defer' => $tool['defer'] ?? null,
         ], fn ($v) => $v !== null), $tools);
 
         $commands = $config['commands'] ?? [];

--- a/src/Types/Tool.php
+++ b/src/Types/Tool.php
@@ -20,6 +20,7 @@ readonly class Tool implements Arrayable
      *                             must be resolved by the consumer via pending external tool request RPCs.
      * @param  bool  $overridesBuiltInTool  Whether this tool overrides a built-in tool with the same name
      * @param  bool  $skipPermission  Whether to skip permission prompt for this tool
+     * @param  ?string  $defer  Controls whether the tool may be deferred (loaded lazily via tool search) rather than always pre-loaded. When `"auto"`, the tool can be deferred and surfaced through tool search. When `"never"`, the tool is always pre-loaded. Optional; defaults to `"auto"`.
      */
     public function __construct(
         public string $name,
@@ -28,6 +29,7 @@ readonly class Tool implements Arrayable
         public ?Closure $handler = null,
         public bool $overridesBuiltInTool = false,
         public bool $skipPermission = false,
+        public ?string $defer = 'auto',
     ) {}
 
     /**
@@ -40,14 +42,23 @@ readonly class Tool implements Arrayable
         ?Closure $handler = null,
         bool $overridesBuiltInTool = false,
         bool $skipPermission = false,
+        ?string $defer = 'auto',
     ): array {
-        return new self($name, $description, $parameters, $handler, $overridesBuiltInTool, $skipPermission)->toArray();
+        return new self(
+            name: $name,
+            description: $description,
+            parameters: $parameters,
+            handler: $handler,
+            overridesBuiltInTool: $overridesBuiltInTool,
+            skipPermission: $skipPermission,
+            defer: $defer,
+        )->toArray();
     }
 
     /**
      * Create from array.
      *
-     * @param  array{name: string, description?: string, parameters?: array, handler?: callable, overridesBuiltInTool?: bool, skipPermission?: bool}  $data
+     * @param  array{name: string, description?: string, parameters?: array, handler?: callable, overridesBuiltInTool?: bool, skipPermission?: bool, defer?: string}  $data
      */
     public static function fromArray(array $data): self
     {
@@ -58,6 +69,7 @@ readonly class Tool implements Arrayable
             handler: $data['handler'] ?? null,
             overridesBuiltInTool: $data['overridesBuiltInTool'] ?? false,
             skipPermission: $data['skipPermission'] ?? false,
+            defer: $data['defer'] ?? 'auto',
         );
     }
 
@@ -81,6 +93,10 @@ readonly class Tool implements Arrayable
 
         if ($this->skipPermission) {
             $array['skipPermission'] = true;
+        }
+
+        if ($this->defer !== null) {
+            $array['defer'] = $this->defer;
         }
 
         return $array;


### PR DESCRIPTION
Introduce a nullable "defer" option for tools to control lazy/deferred loading (defaults to "auto"). Propagate the field through Tool (constructor, define, fromArray, toArray) and include it in Client::createSession and Client::resumeSession tool payloads. Also update Japanese docs (docs/jp/tools.md) to document the new option.